### PR TITLE
add Ondřej Bojar & website translation to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,6 +91,7 @@
 - [Image translation](https://github.com/machinetranslate/machinetranslate.org/issues/92)
 - [Input correction](https://github.com/machinetranslate/machinetranslate.org/issues/93)
 - [Transliteration](https://github.com/machinetranslate/machinetranslate.org/issues/94)
+* Website translation
 
 ### Languages
 
@@ -119,6 +120,7 @@
 - Alon Lavie
 - Lucia Specia
 - [Jaime Carbonell](https://github.com/machinetranslate/machinetranslate.org/issues/106)
+- Ondřej Bojar
 
 ### Community
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,7 @@
 - Social networks
 - Live chat
 - User-generated content
+- Website translation
 - Gaming
 
 ### Concepts - Foundational
@@ -91,7 +92,6 @@
 - [Image translation](https://github.com/machinetranslate/machinetranslate.org/issues/92)
 - [Input correction](https://github.com/machinetranslate/machinetranslate.org/issues/93)
 - [Transliteration](https://github.com/machinetranslate/machinetranslate.org/issues/94)
-* Website translation
 
 ### Languages
 
@@ -121,6 +121,7 @@
 - Lucia Specia
 - [Jaime Carbonell](https://github.com/machinetranslate/machinetranslate.org/issues/106)
 - Ondřej Bojar
+- Martin Popel
 
 ### Community
 


### PR DESCRIPTION
- Adds Ondřej Bojar (an influential research group leader on MT in Prague, long-term WMT organizer) to roadmap.
- Adds website translation as one of the input modes (maybe should be in a different section?). Google Chrome has had that feature for quite a while but in the last few years the [Bergamot](https://browser.mt/) project has been trying to make website translation happen *locally* and add this feature to Firefox. They should both be mentioned, especially the latter because it's a large multi-uni collaboration. 