### PR TITLE
add Czech and German languages to the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -101,6 +101,8 @@
 - [Japanese](https://github.com/machinetranslate/machinetranslate.org/issues/99)
 - [Indic languages](https://github.com/machinetranslate/machinetranslate.org/issues/100)
 - Russian
+- Czech
+- German
 - [Chinese](https://github.com/machinetranslate/machinetranslate.org/issues/101)
 - [Spanish](https://github.com/machinetranslate/machinetranslate.org/issues/102)
 


### PR DESCRIPTION
The Czech languages is very well documented in the current research (maybe even more than Russian, see table in WMT [1]). This is also similar for German. Therefore they should probably have separate entries in the wiki.

[1] [statmt.org/wmt21/translation-task.html](https://statmt.org/wmt21/translation-task.html)