### PR TITLE
Implement Event metadata in JSON-LD for SEO purposes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,4 +30,4 @@ To request a topic, create a new [**issue**](https://github.com/machinetranslate
 
 ### Contributing to infrastructure
 
-To contribute technical work not content, start by reading [README.md](github.com/machinetranslate/machinetranslate.org/README.md).
+To contribute technical work not content, start by reading [README.md](https://github.com/machinetranslate/machinetranslate.org/blob/master/README.md).

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,10 @@ source 'https://rubygems.org'
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 # gem 'jekyll', '~> 4.0.0'
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", '~> 2.5'
+
+# Theme
+gem 'just-the-docs', '0.3.3'
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 gem 'github-pages', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,10 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
+    just-the-docs (0.3.3)
+      jekyll (>= 3.8.5)
+      jekyll-seo-tag (~> 2.0)
+      rake (>= 12.3.1, < 13.1.0)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -242,6 +246,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
     racc (1.6.0)
+    rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -285,9 +290,9 @@ DEPENDENCIES
   jekyll-feed (~> 0.12)
   jekyll-seo-tag
   jekyll-target-blank
-  minima (~> 2.5)
+  just-the-docs (= 0.3.3)
   tzinfo (~> 1.2)
   tzinfo-data
 
 BUNDLED WITH
-   2.3.4
+   2.3.6

--- a/_config.yml
+++ b/_config.yml
@@ -112,7 +112,7 @@ defaults:
 
 # Just the Docs
 
-remote_theme: pmarsceill/just-the-docs
+theme: just-the-docs
 
 logo: favicon.ico
 color_scheme: swissred

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,99 @@
+{% comment %}
+This file was copied from $(bundle info just-the-docs --path)/_includes/head.html.
+Based off just-the-docs v0.3.3.
+{% endcomment %}
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+
+  {% unless site.plugins contains "jekyll-seo-tag" %}
+    <title>{{ page.title }} - {{ site.title }}</title>
+
+    {% if page.description %}
+      <meta name="Description" content="{{ page.description }}">
+    {% endif %}
+  {% endunless %}
+
+  <link rel="shortcut icon" href="{{ 'favicon.ico' | relative_url }}" type="image/x-icon">
+
+  <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
+
+  {% if site.ga_tracking != nil %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.ga_tracking }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '{{ site.ga_tracking }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
+    </script>
+
+  {% endif %}
+
+  {% if site.search_enabled != false %}
+    <script type="text/javascript" src="{{ '/assets/js/vendor/lunr.min.js' | relative_url }}"></script>
+  {% endif %}
+  <script type="text/javascript" src="{{ '/assets/js/just-the-docs.js' | relative_url }}"></script>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  {% if page.seo.type != "Event" -%}
+    {% seo %}
+  {%- else -%}
+    {% comment %}
+    We need to override the information from the JSON-LD structured data section, since the
+    default behavior doesn't cover complex types other than the basic Article.
+    In order to achieve this, we capture the output from the SEO plugin and take over the section
+    within a _script_ tag.
+    {% endcomment %}
+    {% capture seo_text %}{% seo %}{% endcapture %}
+    
+    {% comment %} Extract script tag {% endcomment %}
+    {% assign open_tag = '<script type="application/ld+json">' %}
+    {% assign close_tag = "</script>" %}
+    
+    {% comment %} Remove script tag and contents from `seo_text` {% endcomment %}
+    {% assign extract = seo_text | split: open_tag | last | split: close_tag | first | prepend: open_tag | append: close_tag %}
+    {% assign seo_text = seo_text | remove: extract %}
+    
+    {% comment %}
+    Once we've removed the default value from the script tag, we output the rest of the content
+    and we apply our own -very naive- interpretation of what an JSON-LD Event looks like.
+    {% endcomment %}
+    {{ seo_text }}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Event"
+      {% if page.seo.name %},"name": "{{ page.seo.name }}"{% endif %}
+      {% if page.seo.startDate %},"startDate": "{{ page.seo.startDate }}"{% endif %}
+      {% if page.seo.endDate %},"endDate": "{{ page.seo.endDate }}"{% endif %}
+      {% if page.seo.eventAttendanceMode %},"eventAttendanceMode": "https://schema.org/{{ page.seo.eventAttendanceMode }}"{% endif %}
+      {% if page.seo.eventStatus %},"eventStatus": "https://schema.org/{{ page.seo.eventStatus }}"{% endif %}
+      {% if page.seo.location %},"location": {
+        "@type": "{{ page.seo.location.type }}",
+        {% if page.seo.location.name %},"name": "{{ page.seo.location.name }}"{% endif %}
+        {% if page.seo.location.type == "PostalAddress" %}
+          {% if page.seo.location.addressCountry %},"addressCountry": "{{ page.seo.location.addressCountry }}"{% endif %}
+          {% if page.seo.location.addressLocality %},"addressLocality": "{{ page.seo.location.addressLocality }}"{% endif %}
+          {% if page.seo.location.addressRegion %},"addressRegion": "{{ page.seo.location.addressRegion }}"{% endif %}
+        {% elsif page.seo.location.type == "VirtualLocation" %}
+          {% if page.seo.location.url %}"url": "{{ page.seo.location.url }}"{% endif %}
+        {% endif %}
+      }{% endif %}
+      {% if page.seo.description %},"description": "{{ page.seo.description }}"
+      {% elsif page.description %},"description": "{{ page.description }}"
+      {% endif %}
+      {% if page.seo.organizer %},"organizer": {
+        "@type": "{{ page.seo.organizer.type }}"
+        {% if page.seo.organizer.name %},"name": "{{ page.seo.organizer.name }}"{% endif %}
+        {% if page.seo.organizer.url %},"url": "{{ page.seo.organizer.url }}"{% endif %}
+      }{% endif %}
+    }
+    </script>
+    
+  {%- endif %}
+
+  {% include head_custom.html %}
+
+</head>

--- a/events/aamt2021.md
+++ b/events/aamt2021.md
@@ -3,9 +3,34 @@ parent: Events
 title: AAMT 2021
 description: Conference of the Asian-Pacific Association for Machine Translation
 location: online
-name: AAMT 202
-startDate: 2021-12-08
-endDate: 2021-12-09
+name: AAMT 2021
+seo:
+  type: Event
+  name: AAMT 2021
+  # description: Event description  # In case you want to override the value of the page
+                                    # description, for SEO purposes.
+  startDate: 2021-12-08 # Use ISO8601 format.
+  endDate: 2021-12-09
+  eventAttendanceMode: OnlineEventAttendanceMode  # See possible values in
+                                                  # https://schema.org/EventAttendanceModeEnumeration
+  eventStatus: EventScheduled  # See possible values in https://schema.org/EventStatusType
+  location:  # Commented lines below offered as examples for other articles.
+    # name: Online event  # A readable name for this location.
+
+    # This location object can be of type PostalAddress or VirtualLocation. See examples below:
+
+    # type: PostalAddress
+    # addressCountry: Scotland
+    # addressLocality: Edinburgh
+    # addressRegion: Lothian
+
+    type: VirtualLocation
+    url: https://aamt.info/aamt-2021-online/
+
+  organizer:  # Only supports "type": "Organization", only with "name" and "url" fields.
+    type: Organization
+    name: Asian-Pacific Association for Machine Translation
+    url: https://aamt.info/
 ---
 
 The third Asian-Pacific Association for Machine Translation conference (**AAMT 2021**) took place online from 8 December to 9 December, 2021.


### PR DESCRIPTION
# Description

This adds a very naive implementation to add [structured data for event pages](https://developers.google.com/search/docs/advanced/structured-data/event) using metadata declared in the front matter.

I've modified these attributes in the page for AAMT2021 in order to "document" what information can be exposed.

You can validate whether Google Search can see rich event data by using the [rich results validation tool](https://search.google.com/test/rich-results?utm_campaign=devsite&utm_medium=jsonld&utm_source=event) (compare what you see when pasting the HTML code of any other event page, with what you get from the AAMT2021 page.)

In order to make this work I had to override what the jekyll-seo-tag plugin outputs in the "head.html" include file from the just-the-docs theme. I found it impossible to do that when it was set up as a "remote theme," so I needed to update the Gemfile so it's installed locally. I'm not 100% sure this doesn't break things (perhaps you originally used jekyll remote themes due to some web hosting factor,) but as far as I can tell by testing this locally, things should work OK.

## Type of PR

- Edits: AAMT 2021 (add sample metadata)
- Other: Adds the ability to interpret the `seo` object in the front matter for pages of type Event.

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [ ] I have followed the [style guide](http://machinetranslate.org/style).
- [ ] I have made sure that the URL is not already in use.
- [ ] I have cross-linked relevant articles.
- [ ] I have used the UK spelling.
- [ ] I have kept consistency with the structure of sister articles in the same directory.
