### PR TITLE
Create resources and building

### DIFF
--- a/building/building.md
+++ b/building/building.md
@@ -2,5 +2,5 @@
 nav_order: 21
 has_children: true
 title: Building
-description: Building resources for machine translation
+description: Resources for building machine translation systems
 ---

--- a/building/building.md
+++ b/building/building.md
@@ -1,0 +1,6 @@
+---
+nav_order: 21
+has_children: true
+title: Building
+description: Building resources for machine translation
+---

--- a/building/libraries-frameworks.md
+++ b/building/libraries-frameworks.md
@@ -4,9 +4,9 @@ title: Libraries and frameworks
 description: Libraries and frameworks for building machine translation systems
 ---
 
-## Neural machine translation software
+## Neural machine translation
 
-| Library | Framework | Language |
+| Machine translation library or framework | Machine learning framework | Programming language |
 | --- | --- | --- |
 | [**Argos Translate**](https://github.com/argosopentech/argos-translate) | [PyTorch](https://github.com/pytorch/pytorch) | Python |
 | [**Attention is all you need**](https://github.com/jadore801120/attention-is-all-you-need-pytorch) | PyTorch | Python |
@@ -27,3 +27,8 @@ description: Libraries and frameworks for building machine translation systems
 | [**THUMT-PyTorch**](https://github.com/THUNLP-MT/THUMT) | PyTorch | Python |
 | [**THUMT-TensorFlow**](https://github.com/THUNLP-MT/THUMT/tree/tensorflow) | TensorFlow | Python |
 | [**xnmt**](https://github.com/neulab/xnmt) | [Dynet](https://github.com/clab/dynet) | Python |
+
+
+### References
+
+- [modelfront.com/compare](https://modelfront.com/compare)

--- a/building/libraries-frameworks.md
+++ b/building/libraries-frameworks.md
@@ -1,0 +1,29 @@
+---
+parent: Building
+title: Libraries and frameworks
+description: Libraries and frameworks for building machine translation systems
+---
+
+## Neural machine translation software
+
+| Library | Framework | Language |
+| --- | --- | --- |
+| [**Argos Translate**](https://github.com/argosopentech/argos-translate) | [PyTorch](https://github.com/pytorch/pytorch) | Python |
+| [**Attention is all you need**](https://github.com/jadore801120/attention-is-all-you-need-pytorch) | PyTorch | Python |
+| [**Fairseq**](https://github.com/pytorch/fairseq) |	PyTorch | Python |
+| [**Marian NMT**](https://github.com/marian-nmt/marian) |  | C++ |
+| [**ModernMT**](https://github.com/modernmt/modernmt) | PyTorch, based on [Fairseq](https://github.com/pytorch/fairseq) | Java, Python |
+| [**Nematus**](https://github.com/EdinburghNLP/nematus) | [TensorFlow](https://github.com/tensorflow/tensorflow) | Python |
+| [**NeuralMonkey**](https://github.com/ufal/neuralmonkey) | TensorFlow | Python |
+| [**NiuTrans.NMT**](https://github.com/NiuTrans/NiuTrans.NMT) | [NiuTensor](https://github.com/NiuTrans/NiuTensor) | C++ |
+| [**NMT-Keras**](https://github.com/lvapeab/nmt-keras) | TensorFlow | Python |
+| [**Lingvo**](https://github.com/tensorflow/lingvo) | TensorFlow | Python |
+| [**OpenNMT-py**](https://github.com/OpenNMT/OpenNMT-py) | PyTorch | Python |
+| [**OpenNMT-tf**](https://github.com/OpenNMT/OpenNMT-tf) | TensorFlow | Python |
+| [**seq2seq**](https://github.com/google/seq2seq) | TensorFlow | Python |
+| [**Sockeye**](https://github.com/awslabs/sockeye) | [MXNet](https://github.com/apache/incubator-mxnet) | Python |
+| [**Tensor2Tensor**](https://github.com/tensorflow/tensor2tensor) | TensorFlow | Python |
+| [**Trax Transformer**](https://github.com/google/trax) | Tensorflow | Python |
+| [**THUMT-PyTorch**](https://github.com/THUNLP-MT/THUMT) | PyTorch | Python |
+| [**THUMT-TensorFlow**](https://github.com/THUNLP-MT/THUMT/tree/tensorflow) | TensorFlow | Python |
+| [**xnmt**](https://github.com/neulab/xnmt) | [Dynet](https://github.com/clab/dynet) | Python |

--- a/resources/call-for-papers.md
+++ b/resources/call-for-papers.md
@@ -1,0 +1,17 @@
+---
+parent: Resources
+title: Calls for papers
+description: Calls for papers for machine translation events and publications
+---
+
+### Calls for papers
+
+| Publication | Organisers | Deadline |
+| --- | --- | --- |
+| [WMT22](events/wmt22.md) | [WMT](events/wmt.md) | August 2022 |
+| [AMTA 2022](events/amta2022.md) | [AMTA]() | 06 June 2022 |
+| [*The impact of Machine Translation in the Audiovisual Translation environment*](https://lans-tts.uantwerpen.be/index.php/LANS-TTS/announcement/view/21) | Universitat Jaume I | 01 April 2022 |
+| [EAMT 2022](events/eamt2022.md) | EAMT | 25 March 2022 |
+| [*Special Issue on Translation Platforms*](https://www.aclweb.org/portal/content/special-issue-translation-platforms) | ACL | 15 March 2022 |
+| [IWSLT 2022](events/iwslt2022.md) | IWSLT | 13 March 2022 |
+| [NETTT 2022](events/nettt2022.md) | | 01 March 2022 |

--- a/resources/publications.md
+++ b/resources/publications.md
@@ -4,82 +4,90 @@ title: Publications
 description: Scientific publications about machine translation
 ---
 
-### Neural machine translation
+
+{% include collapsible_toc.html %}
+
+## [Neural machine translation](approaches/neural.machine-translation.md)
 
 |     |     |     |
 | --- | --- | --- |
-| 2017 | [Neural Machine Translation](https://arxiv.org/pdf/1709.07809.pdf) | Philipp Koehn |
+| 2017 | [***Neural Machine Translation***](https://arxiv.org/pdf/1709.07809.pdf) | Philipp Koehn |
 
-
-### Statistical machine Translation
-
-|     |     |     |     |
-| --- | --- | --- | --- |
-| 2007 | [Hierarchical Phrase-Based Translation](https://aclanthology.org/J07-2003.pdf) | David Chiang |
-| 2003 | [Statistical machine translation](https://aclanthology.org/N03-1017.pdf) | Philipp Koehn, Franz Josef Och, Daniel Marcu |
-| 2003 | [Statistical Phrase-Based Translation](https://aclanthology.org/N03-1017.pdf) | Philipp Koehn, Franz Josef Och, Daniel Marcu |
-
-
-### Metrics
-
-|     |     |     |
-| --- | --- | --- |
-| 2020 | [COMET: A Neural Framework for MT Evaluation](https://aclanthology.org/2020.emnlp-main.213.pdf) | Ricardo Rei, Craig Stewart, Ana C Farinha, Alon Lavie |
-| 2014 | [METEOR Universal: Language Specific Translation Evaluation for Any Target Language](https://www.cs.cmu.edu/~alavie/METEOR/pdf/meteor-1.5.pdf) |	Michael Denkowski, Alon Lavie |
-| 2006 | [A study of Translation Edit Rate with Targeted Human Annotation](https://www.cs.umd.edu/~snover/pub/amta06/ter_amta.pdf) | Matthew Snover, Bonnie Dorr, Rich Schwartz, Linnea Micciulla, John Makhoul |
-| 2005 | [METEOR: An Automatic Metric for MT Evaluation with Improved Correlation with Human Judgments](http://www.cs.cmu.edu/~alavie/METEOR/pdf/Banerjee-Lavie-2005-METEOR.pdf) | Satanjeev Banerjee, Alon Lavie |
-| 2004 | [ROUGE: A Package for Automatic Evaluation of Summaries](https://aclanthology.org/W04-1013.pdf) | Chin-Yew Lin |
-| 2003 | [Minimum Error Rate Training in Statistical Machine Translation](https://aclanthology.org/P03-1021.pdf) | Franz Josef Och |
-| 2002 | [BLEU: a Method for Automatic Evaluation of Machine Translation](https://aclanthology.org/P02-1040.pdf) | Kishore Papineni, Salim Roukos, Todd Ward, Wei-Jing Zhu |
 
 
 ### Model architecture
 
 |     |     |     |     |
 | --- | --- | --- | --- |
-| 2018 | [Self-Attention Generative Adversarial Networks](https://arxiv.org/pdf/1805.08318.pdf) | Han Zhang, Ian Goodfellow, Dimitris Metaxas, Augustus Odena |
-| 2017 | [Convolutional Sequence to Sequence Learning](https://arxiv.org/pdf/1705.03122.pdf) | Jonas Gehring, Michael Auli, David Grangier, Denis Yarats, Yann N. Dauphin |
-| 2017 | [Attention is all you need](https://arxiv.org/pdf/1706.03762.pdf) | Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin |
-| 2017 | [Massive Exploration of Neural Machine Translation Architectures](https://arxiv.org/pdf/1703.03906.pdf) | Denny Britz, Anna Goldie, Minh-Thang Luong, Quoc Le |
-| 2017 | [A Deep Reinforced Model for Abstractive Summarization](https://arxiv.org/pdf/1705.04304.pdf) | Romain Paulus, Caiming Xiong, Richard Socher |
-| 2016 | [Google's Neural Machine Translation System: Bridging the Gap between Human and Machine Translation](https://arxiv.org/pdf/1609.08144.pdf) | Yonghui Wu, Mike Schuster, Zhifeng Chen, Quoc V. Le, Mohammad Norouzi, Wolfgang Macherey, Maxim Krikun, Yuan Cao, Qin Gao, Klaus Macherey, Jeff Klingner, Apurva Shah, Melvin Johnson, Xiaobing Liu, Łukasz Kaiser, Stephan Gouws, Yoshikiyo Kato, Taku Kudo, Hideto Kazawa, Keith Stevens, George Kurian, Nishant Patil, Wei Wang, Cliff Young, Jason Smith, Jason Riesa, Alex Rudnick, Oriol Vinyals, Greg Corrado, Macduff Hughes, Jeffrey Dean |
-| 2016 | [Long Short-Term Memory-Networks for Machine Reading](https://arxiv.org/pdf/1601.06733.pdf) | Jianpeng Cheng, Li Dong, Mirella Lapata |
-| 2016 | [Modeling Coverage for Neural Machine Translation](https://aclanthology.org/P16-1008.pdf) | Zhaopeng Tu, Zhengdong Lu, Yang Li, Xiaohua Liu, Hang Li |
-| 2015 | [Neural Machine Translation by Jointly Learning to Align and Translate](https://arxiv.org/pdf/1409.0473.pdf) | Dzmitry Bahdanau, KyungHyun Cho, Yoshua Bengio |
-| 2014 | [On the Properties of Neural Machine Translation: Encoder-Decoder Approaches](https://aclanthology.org/W14-4012.pdf) | Kyunghyun Cho, Bart van Merriënboer, Dzmitry Bahdanau, Yoshua Bengio |
-| 2014 | [Sequence to sequence learning with Neural Networks](https://proceedings.neurips.cc/paper/2014/file/a14ac55a4f27472c5d894ec1c3c743d2-Paper.pdf) | Ilya Sutskever, Oriol Vinyals, Quoc V. Le |
+| 2018 | [***Self-Attention Generative Adversarial Networks***](https://arxiv.org/pdf/1805.08318.pdf) | Han Zhang, Ian Goodfellow, Dimitris Metaxas, Augustus Odena |
+| 2017 | [***Convolutional Sequence to Sequence Learning***](https://arxiv.org/pdf/1705.03122.pdf) | Jonas Gehring, Michael Auli, David Grangier, Denis Yarats, Yann N. Dauphin |
+| 2017 | [***Attention is all you need***](https://arxiv.org/pdf/1706.03762.pdf) | Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin |
+| 2017 | [***Massive Exploration of Neural Machine Translation Architectures***](https://arxiv.org/pdf/1703.03906.pdf) | Denny Britz, Anna Goldie, Minh-Thang Luong, Quoc Le |
+| 2017 | [***A Deep Reinforced Model for Abstractive Summarization***](https://arxiv.org/pdf/1705.04304.pdf) | Romain Paulus, Caiming Xiong, Richard Socher |
+| 2016 | [***Google's Neural Machine Translation System: Bridging the Gap between Human and Machine Translation***](https://arxiv.org/pdf/1609.08144.pdf) | Yonghui Wu, Mike Schuster, Zhifeng Chen, Quoc V. Le, Mohammad Norouzi, Wolfgang Macherey, Maxim Krikun, Yuan Cao, Qin Gao, Klaus Macherey, Jeff Klingner, Apurva Shah, Melvin Johnson, Xiaobing Liu, Łukasz Kaiser, Stephan Gouws, Yoshikiyo Kato, Taku Kudo, Hideto Kazawa, Keith Stevens, George Kurian, Nishant Patil, Wei Wang, Cliff Young, Jason Smith, Jason Riesa, Alex Rudnick, Oriol Vinyals, Greg Corrado, Macduff Hughes, Jeffrey Dean |
+| 2016 | [***Long Short-Term Memory-Networks for Machine Reading***](https://arxiv.org/pdf/1601.06733.pdf) | Jianpeng Cheng, Li Dong, Mirella Lapata |
+| 2016 | [***Modeling Coverage for Neural Machine Translation***](https://aclanthology.org/P16-1008.pdf) | Zhaopeng Tu, Zhengdong Lu, Yang Li, Xiaohua Liu, Hang Li |
+| 2015 | [***Neural Machine Translation by Jointly Learning to Align and Translate***](https://arxiv.org/pdf/1409.0473.pdf) | Dzmitry Bahdanau, KyungHyun Cho, Yoshua Bengio |
+| 2014 | [***On the Properties of Neural Machine Translation: Encoder-Decoder Approaches***](https://aclanthology.org/W14-4012.pdf) | Kyunghyun Cho, Bart van Merriënboer, Dzmitry Bahdanau, Yoshua Bengio |
+| 2014 | [***Sequence to sequence learning with Neural Networks***](https://proceedings.neurips.cc/paper/2014/file/a14ac55a4f27472c5d894ec1c3c743d2-Paper.pdf) | Ilya Sutskever, Oriol Vinyals, Quoc V. Le |
+
 
 
 ### Pre-training
 
 |     |     |     |     |
 | --- | --- | --- | --- |
-| 2019 | [Towards Making the Most of BERT in Neural Machine Translation](https://arxiv.org/pdf/1908.05672.pdf) | Jiacheng Yang, Mingxuan Wang, Hao Zhou, Chengqi Zhao, Yong Yu, Weinan Zhang, Lei Li |
-| 2019 | [On the use of BERT for Neural Machine Translation](https://aclanthology.org/D19-5611.pdf) | Stephane Clinchant, Kweon Woo Jung, Vassilina Nikoulina |
-| 2018 | [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](https://arxiv.org/pdf/1810.04805.pdf) | Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova |
+| 2019 | [***Towards Making the Most of BERT in Neural Machine Translation***](https://arxiv.org/pdf/1908.05672.pdf) | Jiacheng Yang, Mingxuan Wang, Hao Zhou, Chengqi Zhao, Yong Yu, Weinan Zhang, Lei Li |
+| 2019 | [***On the use of BERT for Neural Machine Translation***](https://aclanthology.org/D19-5611.pdf) | Stephane Clinchant, Kweon Woo Jung, Vassilina Nikoulina |
+| 2018 | [***BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding***](https://arxiv.org/pdf/1810.04805.pdf) | Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova |
+
 
 
 ### Attention mechanism
 
 |     |     |     |     |
 | --- | --- | --- | --- |
-| 2017 | [A Structured Self-attentive Sentence Embedding](https://arxiv.org/pdf/1703.03130.pdf) | Zhouhan Lin, Minwei Feng, Cicero Nogueira dos Santos, Mo Yu, Bing Xiang, Bowen Zhou, Yoshua Bengio |
-| 2016 | [A Decomposable Attention Model for Natural Language Inference](https://arxiv.org/pdf/1606.01933.pdf) | Ankur P. Parikh, Oscar Täckström, Dipanjan Das, Jakob Uszkoreit |
-| 2015 | [Effective Approaches to Attention-based Neural Machine Translation](https://aclanthology.org/D15-1166.pdf) | Thang Luong, Hieu Pham, Christopher D. Manning |
+| 2017 | [***A Structured Self-attentive Sentence Embedding***](https://arxiv.org/pdf/1703.03130.pdf) | Zhouhan Lin, Minwei Feng, Cicero Nogueira dos Santos, Mo Yu, Bing Xiang, Bowen Zhou, Yoshua Bengio |
+| 2016 | [***A Decomposable Attention Model for Natural Language Inference***](https://arxiv.org/pdf/1606.01933.pdf) | Ankur P. Parikh, Oscar Täckström, Dipanjan Das, Jakob Uszkoreit |
+| 2015 | [***Effective Approaches to Attention-based Neural Machine Translation***](https://aclanthology.org/D15-1166.pdf) | Thang Luong, Hieu Pham, Christopher D. Manning |
+
 
 
 ### Low-resource translation
 
 |     |     |     |
 | --- | --- | --- |
-| 2018 | [Universal Neural Machine Translation for Extremely Low Resource Languages](https://arxiv.org/pdf/1802.05368.pdf) | 2018 |
-| 2016 | [Google’s Multilingual Neural Machine Translation System: Enabling Zero-Shot Translation](https://aclanthology.org/Q17-1024.pdf) | Melvin Johnson, Mike Schuster, Quoc V. Le, Maxim Krikun, Yonghui Wu, Zhifeng Chen, Nikhil Thorat, Fernanda Viégas, Martin Wattenberg, Greg Corrado, Macduff Hughes, Jeffrey Dean |
-| 2016 | [Improving Neural Machine Translation Models with Monolingual Data](https://aclanthology.org/P16-1009.pdf) | Rico Sennrich, Barry Haddow, Alexandra Birch |
-| 2012 | [On the difficulty of training Recurrent Neural Networks](https://arxiv.org/pdf/1211.5063.pdf) | Razvan Pascanu, Tomas Mikolov, Yoshua Bengio |
+| 2018 | [***Universal Neural Machine Translation for Extremely Low Resource Languages***](https://arxiv.org/pdf/1802.05368.pdf) | Jiatao Gu, Hany Hassan, Jacob Devlin, Victor O.K. Li |
+| 2016 | [***Google’s Multilingual Neural Machine Translation System: Enabling Zero-Shot Translation***](https://aclanthology.org/Q17-1024.pdf) | Melvin Johnson, Mike Schuster, Quoc V. Le, Maxim Krikun, Yonghui Wu, Zhifeng Chen, Nikhil Thorat, Fernanda Viégas, Martin Wattenberg, Greg Corrado, Macduff Hughes, Jeffrey Dean |
+| 2016 | [***Improving Neural Machine Translation Models with Monolingual Data***](https://aclanthology.org/P16-1009.pdf) | Rico Sennrich, Barry Haddow, Alexandra Birch |
+| 2012 | [***On the difficulty of training Recurrent Neural Networks***](https://arxiv.org/pdf/1211.5063.pdf) | Razvan Pascanu, Tomas Mikolov, Yoshua Bengio |
+
 
 
 ### Open vocabulary
 
 |     |     |     |     |
 | --- | --- | --- | --- |
-| 2016 | [Neural Machine Translation of Rare Words with Subword Units](https://arxiv.org/pdf/1508.07909.pdf) | Rico Sennrich, Barry Haddow, Alexandra Birch |
+| 2016 | [***Neural Machine Translation of Rare Words with Subword Units***](https://arxiv.org/pdf/1508.07909.pdf) | Rico Sennrich, Barry Haddow, Alexandra Birch |
+
+
+## [Statistical machine translation](approaches/statistical-machine-translation.md)
+
+|     |     |     |     |
+| --- | --- | --- | --- |
+| 2007 | [***Hierarchical Phrase-Based Translation***](https://aclanthology.org/J07-2003.pdf) | David Chiang |
+| 2003 | [***Statistical machine translation***](https://aclanthology.org/N03-1017.pdf) | Philipp Koehn, Franz Josef Och, Daniel Marcu |
+| 2003 | [***Statistical Phrase-Based Translation***](https://aclanthology.org/N03-1017.pdf) | Philipp Koehn, Franz Josef Och, Daniel Marcu |
+
+
+## Metrics
+
+|     |     |     |
+| --- | --- | --- |
+| 2020 | [***COMET: A Neural Framework for MT Evaluation***](https://aclanthology.org/2020.emnlp-main.213.pdf) | Ricardo Rei, Craig Stewart, Ana C. Farinha, Alon Lavie |
+| 2014 | [***METEOR Universal: Language Specific Translation Evaluation for Any Target Language***](https://www.cs.cmu.edu/~alavie/METEOR/pdf/meteor-1.5.pdf) |	Michael Denkowski, Alon Lavie |
+| 2006 | [***A study of Translation Edit Rate with Targeted Human Annotation***](https://www.cs.umd.edu/~snover/pub/amta06/ter_amta.pdf) | Matthew Snover, Bonnie Dorr, Rich Schwartz, Linnea Micciulla, John Makhoul |
+| 2005 | [***METEOR: An Automatic Metric for MT Evaluation with Improved Correlation with Human Judgments***](http://www.cs.cmu.edu/~alavie/METEOR/pdf/Banerjee-Lavie-2005-METEOR.pdf) | Satanjeev Banerjee, Alon Lavie |
+| 2004 | [***ROUGE: A Package for Automatic Evaluation of Summaries***](https://aclanthology.org/W04-1013.pdf) | Chin-Yew Lin |
+| 2003 | [***Minimum Error Rate Training in Statistical Machine Translation***](https://aclanthology.org/P03-1021.pdf) | Franz Josef Och |
+| 2002 | [***BLEU: a Method for Automatic Evaluation of Machine Translation***](https://aclanthology.org/P02-1040.pdf) | Kishore Papineni, Salim Roukos, Todd Ward, Wei-Jing Zhu |

--- a/resources/publications.md
+++ b/resources/publications.md
@@ -1,0 +1,85 @@
+---
+parent: resources
+title: Publications
+description: Scientific publications about machine translation
+---
+
+### Neural machine translation
+
+|     |     |     |
+| --- | --- | --- |
+| 2017 | [Neural Machine Translation](https://arxiv.org/pdf/1709.07809.pdf) | Philipp Koehn |
+
+
+### Statistical machine Translation
+
+|     |     |     |     |
+| --- | --- | --- | --- |
+| 2007 | [Hierarchical Phrase-Based Translation](https://aclanthology.org/J07-2003.pdf) | David Chiang |
+| 2003 | [Statistical machine translation](https://aclanthology.org/N03-1017.pdf) | Philipp Koehn, Franz Josef Och, Daniel Marcu |
+| 2003 | [Statistical Phrase-Based Translation](https://aclanthology.org/N03-1017.pdf) | Philipp Koehn, Franz Josef Och, Daniel Marcu |
+
+
+### Metrics
+
+|     |     |     |
+| --- | --- | --- |
+| 2020 | [COMET: A Neural Framework for MT Evaluation](https://aclanthology.org/2020.emnlp-main.213.pdf) | Ricardo Rei, Craig Stewart, Ana C Farinha, Alon Lavie |
+| 2014 | [METEOR Universal: Language Specific Translation Evaluation for Any Target Language](https://www.cs.cmu.edu/~alavie/METEOR/pdf/meteor-1.5.pdf) |	Michael Denkowski, Alon Lavie |
+| 2006 | [A study of Translation Edit Rate with Targeted Human Annotation](https://www.cs.umd.edu/~snover/pub/amta06/ter_amta.pdf) | Matthew Snover, Bonnie Dorr, Rich Schwartz, Linnea Micciulla, John Makhoul |
+| 2005 | [METEOR: An Automatic Metric for MT Evaluation with Improved Correlation with Human Judgments](http://www.cs.cmu.edu/~alavie/METEOR/pdf/Banerjee-Lavie-2005-METEOR.pdf) | Satanjeev Banerjee, Alon Lavie |
+| 2004 | [ROUGE: A Package for Automatic Evaluation of Summaries](https://aclanthology.org/W04-1013.pdf) | Chin-Yew Lin |
+| 2003 | [Minimum Error Rate Training in Statistical Machine Translation](https://aclanthology.org/P03-1021.pdf) | Franz Josef Och |
+| 2002 | [BLEU: a Method for Automatic Evaluation of Machine Translation](https://aclanthology.org/P02-1040.pdf) | Kishore Papineni, Salim Roukos, Todd Ward, Wei-Jing Zhu |
+
+
+### Model architecture
+
+|     |     |     |     |
+| --- | --- | --- | --- |
+| 2018 | [Self-Attention Generative Adversarial Networks](https://arxiv.org/pdf/1805.08318.pdf) | Han Zhang, Ian Goodfellow, Dimitris Metaxas, Augustus Odena |
+| 2017 | [Convolutional Sequence to Sequence Learning](https://arxiv.org/pdf/1705.03122.pdf) | Jonas Gehring, Michael Auli, David Grangier, Denis Yarats, Yann N. Dauphin |
+| 2017 | [Attention is all you need](https://arxiv.org/pdf/1706.03762.pdf) | Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N. Gomez, Lukasz Kaiser, Illia Polosukhin |
+| 2017 | [Massive Exploration of Neural Machine Translation Architectures](https://arxiv.org/pdf/1703.03906.pdf) | Denny Britz, Anna Goldie, Minh-Thang Luong, Quoc Le |
+| 2017 | [A Deep Reinforced Model for Abstractive Summarization](https://arxiv.org/pdf/1705.04304.pdf) | Romain Paulus, Caiming Xiong, Richard Socher |
+| 2016 | [Google's Neural Machine Translation System: Bridging the Gap between Human and Machine Translation](https://arxiv.org/pdf/1609.08144.pdf) | Yonghui Wu, Mike Schuster, Zhifeng Chen, Quoc V. Le, Mohammad Norouzi, Wolfgang Macherey, Maxim Krikun, Yuan Cao, Qin Gao, Klaus Macherey, Jeff Klingner, Apurva Shah, Melvin Johnson, Xiaobing Liu, Łukasz Kaiser, Stephan Gouws, Yoshikiyo Kato, Taku Kudo, Hideto Kazawa, Keith Stevens, George Kurian, Nishant Patil, Wei Wang, Cliff Young, Jason Smith, Jason Riesa, Alex Rudnick, Oriol Vinyals, Greg Corrado, Macduff Hughes, Jeffrey Dean |
+| 2016 | [Long Short-Term Memory-Networks for Machine Reading](https://arxiv.org/pdf/1601.06733.pdf) | Jianpeng Cheng, Li Dong, Mirella Lapata |
+| 2016 | [Modeling Coverage for Neural Machine Translation](https://aclanthology.org/P16-1008.pdf) | Zhaopeng Tu, Zhengdong Lu, Yang Li, Xiaohua Liu, Hang Li |
+| 2015 | [Neural Machine Translation by Jointly Learning to Align and Translate](https://arxiv.org/pdf/1409.0473.pdf) | Dzmitry Bahdanau, KyungHyun Cho, Yoshua Bengio |
+| 2014 | [On the Properties of Neural Machine Translation: Encoder-Decoder Approaches](https://aclanthology.org/W14-4012.pdf) | Kyunghyun Cho, Bart van Merriënboer, Dzmitry Bahdanau, Yoshua Bengio |
+| 2014 | [Sequence to sequence learning with Neural Networks](https://proceedings.neurips.cc/paper/2014/file/a14ac55a4f27472c5d894ec1c3c743d2-Paper.pdf) | Ilya Sutskever, Oriol Vinyals, Quoc V. Le |
+
+
+### Pre-training
+
+|     |     |     |     |
+| --- | --- | --- | --- |
+| 2019 | [Towards Making the Most of BERT in Neural Machine Translation](https://arxiv.org/pdf/1908.05672.pdf) | Jiacheng Yang, Mingxuan Wang, Hao Zhou, Chengqi Zhao, Yong Yu, Weinan Zhang, Lei Li |
+| 2019 | [On the use of BERT for Neural Machine Translation](https://aclanthology.org/D19-5611.pdf) | Stephane Clinchant, Kweon Woo Jung, Vassilina Nikoulina |
+| 2018 | [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](https://arxiv.org/pdf/1810.04805.pdf) | Jacob Devlin, Ming-Wei Chang, Kenton Lee, Kristina Toutanova |
+
+
+### Attention mechanism
+
+|     |     |     |     |
+| --- | --- | --- | --- |
+| 2017 | [A Structured Self-attentive Sentence Embedding](https://arxiv.org/pdf/1703.03130.pdf) | Zhouhan Lin, Minwei Feng, Cicero Nogueira dos Santos, Mo Yu, Bing Xiang, Bowen Zhou, Yoshua Bengio |
+| 2016 | [A Decomposable Attention Model for Natural Language Inference](https://arxiv.org/pdf/1606.01933.pdf) | Ankur P. Parikh, Oscar Täckström, Dipanjan Das, Jakob Uszkoreit |
+| 2015 | [Effective Approaches to Attention-based Neural Machine Translation](https://aclanthology.org/D15-1166.pdf) | Thang Luong, Hieu Pham, Christopher D. Manning |
+
+
+### Low-resource translation
+
+|     |     |     |
+| --- | --- | --- |
+| 2018 | [Universal Neural Machine Translation for Extremely Low Resource Languages](https://arxiv.org/pdf/1802.05368.pdf) | 2018 |
+| 2016 | [Google’s Multilingual Neural Machine Translation System: Enabling Zero-Shot Translation](https://aclanthology.org/Q17-1024.pdf) | Melvin Johnson, Mike Schuster, Quoc V. Le, Maxim Krikun, Yonghui Wu, Zhifeng Chen, Nikhil Thorat, Fernanda Viégas, Martin Wattenberg, Greg Corrado, Macduff Hughes, Jeffrey Dean |
+| 2016 | [Improving Neural Machine Translation Models with Monolingual Data](https://aclanthology.org/P16-1009.pdf) | Rico Sennrich, Barry Haddow, Alexandra Birch |
+| 2012 | [On the difficulty of training Recurrent Neural Networks](https://arxiv.org/pdf/1211.5063.pdf) | Razvan Pascanu, Tomas Mikolov, Yoshua Bengio |
+
+
+### Open vocabulary
+
+|     |     |     |     |
+| --- | --- | --- | --- |
+| 2016 | [Neural Machine Translation of Rare Words with Subword Units](https://arxiv.org/pdf/1508.07909.pdf) | Rico Sennrich, Barry Haddow, Alexandra Birch |

--- a/resources/resources.md
+++ b/resources/resources.md
@@ -1,0 +1,16 @@
+---
+nav_order: 121
+has_children: true
+title: Publications
+description: Machine translation publications
+---
+
+### Calls for papers
+
+| Publication | Organisers | Deadline | Type |
+| --- | --- | --- | --- |
+| [The impact of Machine Translation in the Audiovisual Translation environment](https://lans-tts.uantwerpen.be/index.php/LANS-TTS/announcement/view/21) | Universitat Jaume I | April 01, 2022 | Scientific publication |
+| [EAMT 2022](events/eamt2022.md) | EAMT | March 25, 2022 | Conference |
+| [Special Issue on Translation Platforms](https://www.aclweb.org/portal/content/special-issue-translation-platforms) | ACL | March 15, 2022 | Scientific publication |
+| [IWSLT 2022](events/iwslt2022.md) | IWSLT | March 13, 2022 | Conference |
+| [NETTT 2022](events/nettt2022.md) | | March 01, 2022 | Conference |

--- a/resources/resources.md
+++ b/resources/resources.md
@@ -4,13 +4,3 @@ has_children: true
 title: Resources
 description: Machine translation resources
 ---
-
-### Calls for papers
-
-| Publication | Organisers | Deadline | Type |
-| --- | --- | --- | --- |
-| [The impact of Machine Translation in the Audiovisual Translation environment](https://lans-tts.uantwerpen.be/index.php/LANS-TTS/announcement/view/21) | Universitat Jaume I | April 01, 2022 | Scientific publication |
-| [EAMT 2022](events/eamt2022.md) | EAMT | March 25, 2022 | Conference |
-| [Special Issue on Translation Platforms](https://www.aclweb.org/portal/content/special-issue-translation-platforms) | ACL | March 15, 2022 | Scientific publication |
-| [IWSLT 2022](events/iwslt2022.md) | IWSLT | March 13, 2022 | Conference |
-| [NETTT 2022](events/nettt2022.md) | | March 01, 2022 | Conference |

--- a/resources/resources.md
+++ b/resources/resources.md
@@ -1,8 +1,8 @@
 ---
 nav_order: 121
 has_children: true
-title: Publications
-description: Machine translation publications
+title: Resources
+description: Machine translation resources
 ---
 
 ### Calls for papers


### PR DESCRIPTION
# Description
Draft for libraries-frameworks.md
Draft for publications.md

In Libraries-frameworks, I created a big table following the example from ModelFront.

In Publications, I left out certain publications which I could not find for free, ie. Early years in Machine Translation, by Hutchins. (Maybe I can mention it without the link?).

These are first drafts.

Fixes #87 


## Type of PR

- Creates the articles:
   - libraries-frameworks.md
   - publications.md


### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
- [x] I have made sure that the URL is not already in use.
- [x] I have cross-linked relevant articles.
- [x] I have used the UK spelling.
- [x] I have kept consistency with the structure of sister articles in the same directory.
