### PR TITLE
wrap links, resolve #217

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -20,6 +20,11 @@
     font-weight: lighter;
   }
 
+  // all links
+  a {
+    white-space: pre-wrap;
+  }
+
   blockquote {
     background-color: $grey-lt-000;
     padding: 0.1em;

--- a/resources/publications.md
+++ b/resources/publications.md
@@ -17,9 +17,6 @@ td:nth-child(1) {
 td:nth-child(2) {
   min-width: 300px;
 }
-.main-content a {
-  white-space: pre-wrap; 
-}
 </style>
 
 


### PR DESCRIPTION
# Description

Fixes #217 by adding `whitespace: pre-wrap` to all links. There was already an override in `publications.md` (on this note I think we should strictly avoid custom `<style>` in separate pages unless there's a strict need.

Notes:
- @bittlingmayer I am not sure if the css is automatically generated from sass on merge or whether there is a custom action that needs to be run.
- I have not tested this as I don't have the prod-ready environment set up locally. Despite that I think this is a reasonable style and I wonder why `nowrap` is the default anyway.

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style). *the style does not cover "coding"*
- [x] I have made sure that the URL is not already in use. *does not apply*
- [x] I have cross-linked relevant articles. *does not apply*
- [x] I have used the UK spelling. *does not apply*
- [x] I have kept consistency with the structure of sister articles in the same directory. *does not apply*
