### PR TITLE
update footer

### DIFF
--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -18,9 +18,7 @@
     </p>
   {% else %}
     <p id="edited" style="display: none;">
-      Edited on <span id="edited-date"></span> by <a id="edited-username"></a>
-    </p>
-    <p>
+      Edited on <span id="edited-date"></span> by <a id="edited-username"></a>.
       <a
         target="_blank"
         href="https://github.com/machinetranslate/machinetranslate.org/blob/master/{{ page.path }}">
@@ -33,12 +31,10 @@
 <center>
   <p>
       Machine Translate is created and edited by contributors like you!
-  </p>
-  <p>
-    <a
-      href="/contributing">
-      Learn more about contributing
-    </a>
+    </p>
+    <p>
+      <a href="/contributing">Learn more about contributing.</a>
+      Licensed under <a target="_blank" href="http://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA-4.0</a>.
   </p>
 </center>
 


### PR DESCRIPTION
# Description

Resolves #208 by adding `CC-BY-SA-4.0` to the footer. I did not add *GmbH* because to me the phrase *Machine Translate GmbH is created and edited by contributors like you!* sounds too corporate and bit non-sensical and it would slightly deter me from contributing (I'd ask myself: *Do I need to be part of this GmbH? I just want to contribute to an open source project a bit. What is all this?*). If @cefoo wishes, I may add it (or some other phrasing).

I also removed the vertical whitespace between *Edited on .. by..* and *Edit this article* to make the footer shorter. I like it more but indeed this is opinionated design and if the maintainers wish, I can roll this back.

Note: Not tested locally.

## Type of PR

Change footer template.

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style). *does not apply*
- [x] I have made sure that the URL is not already in use. *does not apply*
- [x] I have cross-linked relevant articles. *does not apply*
- [x] I have used the UK spelling. *does not apply*
- [x] I have kept consistency with the structure of sister articles in the same directory. *does not apply*