### PR TITLE
add reviewing as a possible contribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ To create or edit an article, [**create**](https://github.com/machinetranslate/m
 
 > See GitHub’s article [*Creating a pull request*](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request#creating-the-pull-request) for more.
 
-### Reviewing articles
+### Reviewing proposed changes
 
-You can also contribute by reviewing other contributors' [open pull requests](https://github.com/machinetranslate/machinetranslate.org/pulls?q=is%3Aopen+is%3Apr) via comments and iterate with them to improve the articles.
+You can also contribute by reviewing other contributors' [open pull requests](https://github.com/machinetranslate/machinetranslate.org/pulls?q=is%3Aopen+is%3Apr).
 
 > See GitHub’s article [*Commenting on a pull request*](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request ) for more.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,19 +12,23 @@ Machine Translate is **created and edited by [contributors like you!](contributi
 
 We recommend reading the [**roadmap**](/roadmap.md) and [**style guide**](contributing/style.md) before you start contributing.
 
-
 ### Creating and editing articles
 
 To create or edit an article, [**create**](https://github.com/machinetranslate/machinetranslate.org/new/master) or [**edit**](https://github.com/machinetranslate/machinetranslate.org) and send us a [pull request](https://github.com/machinetranslate/machinetranslate.org/pulls?q=is%3Apr).
 
-> See GitHub’s article [*Creating a pull request*](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request#creating-the-pull-request) for more
+> See GitHub’s article [*Creating a pull request*](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request#creating-the-pull-request) for more.
 
+### Reviewing articles
+
+You can also contribute by reviewing other contributors' [open pull requests](https://github.com/machinetranslate/machinetranslate.org/pulls?q=is%3Aopen+is%3Apr) via comments and iterate with them to improve the articles.
+
+> See GitHub’s article [*Commenting on a pull request*](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request ) for more.
 
 ### Requesting articles
 
 To request a topic, create a new [**issue**](https://github.com/machinetranslate/machinetranslate.org/issues).
 
-> See GitHub’s article [*Creating an issue*](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-repository) for more
+> See GitHub’s article [*Creating an issue*](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-repository) for more.
 
 ---
 


### PR DESCRIPTION
As was suggested during our chat, this adds *reviewing* as one of the possible contributions. Currently the pipeline is:

1. Issue is created (by any contributor)
2. A contributor picks up this issue, writes a draft of the article and files a PR
3. Adam reviews the article (+iterates)
4. Several iterations of changes are made be the original contributor
5. Adam merges the PR

This obviously does not scale and Adam becomes the bottleneck. Having someone else in place of Adam on step 3 would reduce the workload on him and he could be involved only in step 5 for final quality check.

I did not include this justification in the contributing file to keep it brief but believe that it'd be a step in the right direction (possibly with different wording) because a newcomer may think that reviewing is only reserved for "core maintainers".

Quality of the merged articles would not decrease because Adam would still read the final article at least once (though something could be done about that as well (democratization :slightly_smiling_face: )).

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
- [x] I have made sure that the URL is not already in use.
- [x] I have cross-linked relevant articles.
- [x] I have used the UK spelling.
- [x] I have kept consistency with the structure of sister articles in the same directory.
