### PR TITLE
Update results of wmt20

### DIFF
--- a/events/wmt20.md
+++ b/events/wmt20.md
@@ -217,3 +217,49 @@ Friday, November 20, 2020
 | | [***The Tatoeba Translation Challenge – Realistic Data Sets for Low Resource and Multilingual MT***](https://aclanthology.org/2020.wmt-1.139.pdf) <br>Jörg Tiedemann |
 | | [***Human-Paraphrased References Improve Neural Machine Translation***](https://aclanthology.org/2020.wmt-1.140.pdf) <br>Markus Freitag, George Foster, David Grangier and Colin Cherry |
 | |	[***Incorporating Terminology Constraints in Automatic Post-Editing***](https://aclanthology.org/2020.wmt-1.141.pdf) <br>David Wan, Chris Kedzie, Faisal Ladhak, Marine Carpuat and Kathleen McKeown |
+
+## Results
+
+#### Full results of the shared tasks: [***Findings of the 2020 Conference on Machine Translation (WMT20)***](https://aclanthology.org/2020.wmt-1.1.pdf)
+
+### News Translation
+
+#### → English
+> *Systems ordered by Direct Assessment score z-score
+
+| Language pair | Annotation style | Average score | Average z-score (standard score) | System |
+| --- | --- | --- | --- | --- |
+| Chinese→English | Segment rating with document context | 77.5 | 0.102 | `VolcTrans` |
+| Czech→English | Segment rating with document context | 78.3 | 0.118 | `CUNI-DocTransformer` |
+| German→English | Segment rating with document context | 82.6 | 0.228 | `VolcTrans` |
+| Inuktitut→English | Segment rating without document context | 73.1 | 0.168 | `NiuTrans` |
+| Japanese→English | Segment rating with document context | 75.1 | 0.184 | `Tohoku-AIP-NTT` |
+| Khmer→English | Segment rating without document context | 69.0 | 0.168 | `Online-B` |
+| Pashto→English | Segment rating without document context | 67.3 | 0.032 | `Online-B` |
+| Polish→English | Segment rating with document context | 77.2 | 0.131 | `SRPOL` |
+| Russian→English | Segment rating with document context | 79.3 | 0.124 | `Online-G` |
+| Tamil→English | Segment rating with document context | 68.7 | 0.203 | `GTCOM` |
+
+#### English →
+> *Systems ordered by Direct Assessment score z-score
+
+| Language pair | Annotation style | Average score | Average z-score (standard score) | System |
+| --- | --- | --- | --- | --- |
+| English→Chinese | Segment rating with document context | 80.6 | 0.568 | `HUMAN-B` |
+| English→Czech | Segment rating with document context | 85.6 | 0.654 | `HUMAN` |
+| English→German | Segment rating with document context | 90.5 | 0.569 | `HUMAN-B` |
+| English→Inuktitut (News only) | Segment rating without document context | 90.5 | 0.574 | `HUMAN` |
+| English→Japanese | Segment rating with document context | 79.7 | 0.576 | `HUMAN` |
+| English→Polish | Segment rating with document context | 88.6 | 0.672 | `HUMAN` |
+| English→Russian | Segment rating with document context | 91.8 | 0.681 | `HUMAN` |
+| English→Tamil | Segment rating with document context | 83.4 | 0.762 | `HUMAN` |
+| English→Khmer | Segment rating without document context | 77.4 | 0.478 | `GTCOM` |
+| English→Pashto | Segment rating without document context | 73.0 | 0.244 | `GTCOM` |
+
+#### French to/from German (segment rating without document context)
+> *Systems ordered by Direct Assessment score z-score
+
+| Language pair | Average score | Average z-score (standard score) | System |
+| --- | --- | --- | --- |
+| German→French | 90.4 | 0.279 | `OPPO` |
+| French→German | 89.8 | 0.334 | `VolcTrans` |


### PR DESCRIPTION
# Description
I've added the winner list of the wmt20 news translation task. However, there are several things I'd like to discuss, such as 

1. Merging vertical cells where the annotation style is repeated. I've put it separately on each line to make the winner list more comprehensive, but it doesn't seem visually appealing to me, which is why I would like to hear your opinion on this as well. 
2. Excluding the English→Inuktitut results from the second table as it only illustrates the results of the News test set while skipping Hansard. I've included this info in brackets, but as I couldn't find the complete results, I find it misleading to put English→Inuktitut in the winner list with only half the information available. 

## Type of PR
Adding news translation task results of wmt20


### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
- [x] I have made sure that the URL is not already in use.
- [x] I have cross-linked relevant articles.
- [x] I have used the UK spelling.
- [x] I have kept consistency with the structure of sister articles in the same directory.
