### PR TITLE
add Ondřej Bojar and DFKI

### DIFF
--- a/events/wmt.md
+++ b/events/wmt.md
@@ -89,7 +89,7 @@ The results published from WMT shared tasks represent benchmarks for the technol
 - [Philipp Koehn](/community/people/philipp-koehn.md)
 - Barry Haddow
 - Loïc Barrault
-- Ondřej Bojar
+- [Ondřej Bojar](/community/people/ondrej-bojar.md)
 - Marco Turchi
 - Martin Popel
 - Matt Post

--- a/people/ondrej-bojar.md
+++ b/people/ondrej-bojar.md
@@ -6,12 +6,12 @@ description: Machine translation researcher and associate professor
 ---
 
 **Ondřej Bojar** is a machine translation researcher at the [Institute of Formal and Applied Linguistics](https://ufal.mff.cuni.cz/) at Charles University in Prague.
-He became an associate professor in 2019 and his work on [statistical](/statistical-machine-translation) and later [neural machine translation](/neural-machine-translation) is widely cited.
-He co-authored [Moses](http://www2.statmt.org/moses/), a system for statistical machine translation and is a long-term organizer of [WMT](/events/wmt.md).
+He became an associate professor in 2019 and his work on [statistical](/../approaches/statistical-machine-translation.md) and later [neural machine translation](/../approaches/neural-machine-translation.md) is widely cited.
+He co-authored [Moses](http://www2.statmt.org/moses/), a system for statistical machine translation and is a long-term organizer of [WMT](/../events/wmt.md).
 
 ## Research topics
 - interactive machine translation
-- machine translation [post-editing](/post-editing)
+- machine translation [post-editing](/../workflows/post-editing.md)
 - psycholinguistic aspects of machine translation
 
 ## Projects

--- a/people/ondrej-bojar.md
+++ b/people/ondrej-bojar.md
@@ -2,11 +2,13 @@
 grand_parent: Community
 parent: People
 title: Ondřej Bojar
-description: Machine translation researcher
+description: Machine translation researcher and associate professor
 ---
 
-**Ondřej Bojar** is a researcher and associate professor at the [Institute of Formal and Applied Linguistics](https://ufal.mff.cuni.cz/) at Charles University in Prague, widely cited for his work on statistical and later [neural machine translation](/neural-machine-translation).
-He co-authored Moses, a kit for [statistical machine translation](/statistical-machine-translation) and is a long-term organizer of [WMT](/community/communities.md#workshop_on_statistical_machine_translation).
+**Ondřej Bojar** is a researcher and associate professor at the [Institute of Formal and Applied Linguistics](https://ufal.mff.cuni.cz/) at Charles University in Prague.
+He is widely cited for his work on [statistical](/statistical-machine-translation) and later [neural machine translation](/neural-machine-translation).
+He co-authored Moses, a kit for statistical machine translation and is a long-term organizer of [WMT](/events/wmt.md).
 
 His work goes beyond mainstream machine translation, such as interactive machine translation, post-editing or psycholinguistical aspects of machine translation usage.
-He managed Charles University's participation in the [Bergamot](https://browser.mt/) project for browser-based machine translation and the [ELITR](https://elitr.eu/) project for simultaneous translation of European languages and is the author of [CzEng](https://ufal.mff.cuni.cz/czeng), the Czech-English parallel corpus with over 60 million authentic sentence pairs.
+He managed Charles University's participation in the [Bergamot](https://browser.mt/) project for browser-based machine translation and the [ELITR](https://elitr.eu/) project for simultaneous translation of European languages.
+He is the author of [CzEng](https://ufal.mff.cuni.cz/czeng), the Czech-English parallel corpus with over 60 million authentic sentence pairs.

--- a/people/ondrej-bojar.md
+++ b/people/ondrej-bojar.md
@@ -1,0 +1,12 @@
+---
+grand_parent: Community
+parent: People
+title: Ondřej Bojar
+description: Machine translation researcher
+---
+
+**Ondřej Bojar** is a researcher and associate professor at the [Institute of Formal and Applied Linguistics](https://ufal.mff.cuni.cz/) at Charles University in Prague, widely cited for his work on statistical and later [neural machine translation](/neural-machine-translation).
+He co-authored Moses, a kit for [statistical machine translation](/statistical-machine-translation) and is a long-term organizer of [WMT](/community/communities.md#workshop_on_statistical_machine_translation).
+
+His work goes beyond mainstream machine translation, such as interactive machine translation, post-editing or psycholinguistical aspects of machine translation usage.
+He managed Charles University's participation in the [Bergamot](https://browser.mt/) project for browser-based machine translation and the [ELITR](https://elitr.eu/) project for simultaneous translation of European languages and is the author of [CzEng](https://ufal.mff.cuni.cz/czeng), the Czech-English parallel corpus with over 60 million authentic sentence pairs.

--- a/people/ondrej-bojar.md
+++ b/people/ondrej-bojar.md
@@ -5,10 +5,16 @@ title: Ondřej Bojar
 description: Machine translation researcher and associate professor
 ---
 
-**Ondřej Bojar** is a researcher and associate professor at the [Institute of Formal and Applied Linguistics](https://ufal.mff.cuni.cz/) at Charles University in Prague.
-He is widely cited for his work on [statistical](/statistical-machine-translation) and later [neural machine translation](/neural-machine-translation).
-He co-authored Moses, a kit for statistical machine translation and is a long-term organizer of [WMT](/events/wmt.md).
+**Ondřej Bojar** is a machine translation researcher and since 2010 an associate professor at the [Institute of Formal and Applied Linguistics](https://ufal.mff.cuni.cz/) at Charles University in Prague.
+His work on [statistical](/statistical-machine-translation) and later [neural machine translation](/neural-machine-translation) is widely cited.
+He co-authored [Moses](http://www2.statmt.org/moses/), a system for statistical machine translation and is a long-term organizer of [WMT](/events/wmt.md).
 
-His work goes beyond mainstream machine translation, such as interactive machine translation, post-editing or psycholinguistical aspects of machine translation usage.
-He managed Charles University's participation in the [Bergamot](https://browser.mt/) project for browser-based machine translation and the [ELITR](https://elitr.eu/) project for simultaneous translation of European languages.
-He is the author of [CzEng](https://ufal.mff.cuni.cz/czeng), the Czech-English parallel corpus with over 60 million authentic sentence pairs.
+## Research topics
+- interactive machine translation
+- machine translation [post-editing](/post-editing)
+- psycholinguistic aspects of machine translation
+
+## Projects
+- [Bergamot](https://browser.mt/): browser-based machine translation
+- [ELITR](https://elitr.eu/): simultaneous translation of European languages
+- [CzEng](https://ufal.mff.cuni.cz/czeng): large Czech-English parallel corpus

--- a/people/ondrej-bojar.md
+++ b/people/ondrej-bojar.md
@@ -5,8 +5,8 @@ title: Ondřej Bojar
 description: Machine translation researcher and associate professor
 ---
 
-**Ondřej Bojar** is a machine translation researcher and since 2010 an associate professor at the [Institute of Formal and Applied Linguistics](https://ufal.mff.cuni.cz/) at Charles University in Prague.
-His work on [statistical](/statistical-machine-translation) and later [neural machine translation](/neural-machine-translation) is widely cited.
+**Ondřej Bojar** is a machine translation researcher at the [Institute of Formal and Applied Linguistics](https://ufal.mff.cuni.cz/) at Charles University in Prague.
+He became an associate professor in 2019 and his work on [statistical](/statistical-machine-translation) and later [neural machine translation](/neural-machine-translation) is widely cited.
 He co-authored [Moses](http://www2.statmt.org/moses/), a system for statistical machine translation and is a long-term organizer of [WMT](/events/wmt.md).
 
 ## Research topics

--- a/research-laboratories/research-laboratories.md
+++ b/research-laboratories/research-laboratories.md
@@ -9,32 +9,32 @@ description: Machine translation research laboratories
 | --- | --- | --- | --- |
 | [**ADAPT Centre**](https://www.adaptcentre.ie/) | Science Foundation Ireland | Academic | Ireland |
 | [**Applied Research in Computational Linguistics**](http://rali.iro.umontreal.ca/rali/?q=en/Research%20Projects) | University of Montreal | Academic | Canada |
-| [**The Berkeley NLP Group**](http://nlp.cs.berkeley.edu/) | University of California | Academic | US |
-| [**Center of Language and Speech Processing**](https://www.clsp.jhu.edu/) | Johns Hopkins University | Academic | US |
-| [**Computational Linguistics and Information Processing**](https://wiki.umiacs.umd.edu/clip/index.php/Main_Page) | University of Maryland | Academic | US |
+| [**The Berkeley NLP Group**](http://nlp.cs.berkeley.edu/) | University of California | Academic | USA |
+| [**Center of Language and Speech Processing**](https://www.clsp.jhu.edu/) | Johns Hopkins University | Academic | USA |
+| [**Computational Linguistics and Information Processing**](https://wiki.umiacs.umd.edu/clip/index.php/Main_Page) | University of Maryland | Academic | USA |
 | [**Computational Linguistics Research Group**](http://www.cs.toronto.edu/compling/) | University of Toronto | Academic | Canada |
-| [**Conversational AI & Natural-Language Processing**](https://www.amazon.science/research-areas/conversational-ai-natural-language-processing) | Amazon | Corporate | US |
-| [**MT Team @ DFKI**](https://www.dfki.de/en/web/research/research-departments/multilinguality-and-language-technology/mt-team) | DFKI | Academic | Germany |
+| [**Conversational AI / Natural-Language Processing**](https://www.amazon.science/research-areas/conversational-ai-natural-language-processing) | Amazon | Corporate | USA |
+| [**MT Team at DFKI**](https://www.dfki.de/en/web/research/research-departments/multilinguality-and-language-technology/mt-team) | DFKI | Academic | Germany |
 | [**GETALP**](http://lig-getalp.imag.fr/) | Laboratoire d’Informatique de Grenoble | Academic | France |
-| [**Google Research**](https://research.google/research-areas/machine-translation/) | Google | Corporate | US |
+| [**Google Research**](https://research.google/research-areas/machine-translation/) | Google | Corporate | USA |
 | [**Helsinki-NLP**](https://blogs.helsinki.fi/language-technology/ ) | University of Helsinki | Academic | Finland |
 | [**Human Language Technology**](https://hlt-mt.fbk.eu/) | Fondazione Bruno Kessler | Corporate | Italy |
 | [**Institute of Computational Linguistics**](https://www.cl.uzh.ch) | University of Zurich | Academic | Switzerland |
 | [**Institute of Formal and Applied Linguistics**](https://ufal.mff.cuni.cz/home-page) | Charles University | Academic | Czech Republic |
-| [**Language Technologies Institute**](https://www.lti.cs.cmu.edu/) | Carnegie Mellow University | Academic | US |
+| [**Language Technologies Institute**](https://www.lti.cs.cmu.edu/) | Carnegie Mellow University | Academic | USA |
 | [**Language and Translation Technology group**](https://lt3.ugent.be/) | Ghent University | Academic | Belgium |
 | [**Machine Translation group**](https://mt.cs.upc.edu/) | Universitat Politècnica de Catalunya | Academic | Spain |
-| [**Machine Translation Group**](https://www.microsoft.com/en-us/research/group/machine-translation-group/) | Microsoft | Corporate | US |
-| [**Machine Translation Research**](https://www.cs.rochester.edu/~gildea/mt/) | University of Rochester | Academic | US |
+| [**Machine Translation Group**](https://www.microsoft.com/en-us/research/group/machine-translation-group/) | Microsoft | Corporate | USA |
+| [**Machine Translation Research**](https://www.cs.rochester.edu/~gildea/mt/) | University of Rochester | Academic | USA |
 | [**Machine Translation System Laboratory**](https://cicc.or.jp/english/) | Center for the International Cooperation for Computerization | Governmental | Japan |
-| [**The Natural Language Group**](https://www.isi.edu/research_groups/nlg/home) | University of Southern California | Academic | US |
+| [**The Natural Language Group**](https://www.isi.edu/research_groups/nlg/home) | University of Southern California | Academic | USA |
 | [**Natural Language Laboratory**](http://natlang.cs.sfu.ca/) | Simon Fraser University | Academic | Canada |
-| [**Natural Language Processing Group**](https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Research-Areas/Natural-Language-Processing) | City University of New York | Academic | US |
-| [**Natural Language Processing Group**](https://www.cis.upenn.edu/) | University of Pennsylvania | Academic | US |
-| [**Natural Language Processing research**](http://www1.cs.columbia.edu/nlp/index.cgi) | Columbia University | Academic | US |
-| [**Natural Language Processing**](https://www.cs.washington.edu/research/nlp) | University of Washington | Academic | US |
+| [**Natural Language Processing Group**](https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Research-Areas/Natural-Language-Processing) | City University of New York | Academic | USA |
+| [**Natural Language Processing Group**](https://www.cis.upenn.edu/) | University of Pennsylvania | Academic | USA |
+| [**Natural Language Processing research**](http://www1.cs.columbia.edu/nlp/index.cgi) | Columbia University | Academic | USA |
+| [**Natural Language Processing**](https://www.cs.washington.edu/research/nlp) | University of Washington | Academic | USA |
 | [**Neural Machine Translation**](https://www.microsoft.com/en-us/research/project/machine-translation-2/) | Microsoft | Corporate | China |
 | [**Research Group**](https://www.rws.com/language-weaver/research/) | SDL | Corporate | UK |
 | [**Statistical Machine Translation Group**](http://www.statmt.org/ued/) | University of Edinburgh | Academic | UK |
-| [**Speech Technology and Research (STAR) Laboratory**](http://www.speech.sri.com/) | SRI International | Corporate | US |
-| [**The Stanford Natural Language Processing Group**](https://nlp.stanford.edu/projects/mt.shtml) | Stanford University | Academic | US |
+| [**Speech Technology and Research (STAR) Laboratory**](http://www.speech.sri.com/) | SRI International | Corporate | USA |
+| [**The Stanford Natural Language Processing Group**](https://nlp.stanford.edu/projects/mt.shtml) | Stanford University | Academic | USA |

--- a/research-laboratories/research-laboratories.md
+++ b/research-laboratories/research-laboratories.md
@@ -14,9 +14,10 @@ description: Machine translation research laboratories
 | [**Computational Linguistics and Information Processing**](https://wiki.umiacs.umd.edu/clip/index.php/Main_Page) | University of Maryland | Academic | US |
 | [**Computational Linguistics Research Group**](http://www.cs.toronto.edu/compling/) | University of Toronto | Academic | Canada |
 | [**Conversational AI & Natural-Language Processing**](https://www.amazon.science/research-areas/conversational-ai-natural-language-processing) | Amazon | Corporate | US |
-| [**Helsinki-NLP**](https://blogs.helsinki.fi/language-technology/ ) | University of Helsinki | Academic | Finland |
+| [**MT Team @ DFKI**](https://www.dfki.de/en/web/research/research-departments/multilinguality-and-language-technology/mt-team) | DFKI | Academic | Germany |
 | [**GETALP**](http://lig-getalp.imag.fr/) | Laboratoire d’Informatique de Grenoble | Academic | France |
 | [**Google Research**](https://research.google/research-areas/machine-translation/) | Google | Corporate | US |
+| [**Helsinki-NLP**](https://blogs.helsinki.fi/language-technology/ ) | University of Helsinki | Academic | Finland |
 | [**Human Language Technology**](https://hlt-mt.fbk.eu/) | Fondazione Bruno Kessler | Corporate | Italy |
 | [**Institute of Computational Linguistics**](https://www.cl.uzh.ch) | University of Zurich | Academic | Switzerland |
 | [**Institute of Formal and Applied Linguistics**](https://ufal.mff.cuni.cz/home-page) | Charles University | Academic | Czech Republic |


### PR DESCRIPTION
# Description

Fixes #169 (Ondřej Bojar) and lists DFKI, a potent German research institute, in research laboratories.
It also reorders the list to be alphabetically sorted.

## Type of PR

- Creates the article _Ondřej Bojar_
- Edits _Research laboratories_

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
- [x] I have made sure that the URL is not already in use.
- [x] I have cross-linked relevant articles.
- [x] I have used the UK spelling.
- [x] I have kept consistency with the structure of sister articles in the same directory.
