### PR TITLE
Rearranges Applications

### DIFF
--- a/applications/applications.md
+++ b/applications/applications.md
@@ -1,7 +1,8 @@
 ---
-nav_order: 11
+nav_order: 10
 has_children: true
-parent: Products and applications
-title: Applications
+title: Application areas
 description: Applications of machine translation
 ---
+
+Machine translation is applied to multiple areas.

--- a/applications/commerce-and-marketplaces.md
+++ b/applications/commerce-and-marketplaces.md
@@ -1,6 +1,6 @@
 ---
-grand_parent: Products and applications
-parent: Applications
+nav_order: 1
+parent: Application areas
 title: Commerce and marketplaces
 description: Machine translation for commerce and marketplaces
 ---

--- a/applications/gaming.md
+++ b/applications/gaming.md
@@ -1,6 +1,6 @@
 ---
-grand_parent: Products and applications
-parent: Applications
+nav_order: 2
+parent: Application areas
 title: Gaming
 description: Machine translation for gaming
 ---

--- a/applications/live-chat.md
+++ b/applications/live-chat.md
@@ -1,6 +1,6 @@
 ---
-grand_parent: Products and applications
-parent: Applications
+nav_order: 8
+parent: Application areas
 title: Live chat
 description: Machine translation for live chat
 ---

--- a/applications/multilingual-search.md
+++ b/applications/multilingual-search.md
@@ -1,6 +1,6 @@
 ---
-grand_parent: Products and applications
-parent: Applications
+nav_order: 6
+parent: Application areas
 title: Multilingual search
 description: Machine translation for multilingual search
 ---

--- a/applications/seo.md
+++ b/applications/seo.md
@@ -1,6 +1,6 @@
 ---
-grand_parent: Products and applications
-parent: Applications
+nav_order: 7
+parent: Application areas
 title: SEO
 description: Machine translation for SEO
 ---

--- a/applications/social-networks.md
+++ b/applications/social-networks.md
@@ -1,6 +1,6 @@
 ---
-grand_parent: Products and applications
-parent: Applications
+nav_order: 3
+parent: Application areas
 title: Social networks
 description: Machine translation for social networks
 ---

--- a/applications/translation-and-localisation.md
+++ b/applications/translation-and-localisation.md
@@ -1,6 +1,7 @@
 ---
-grand_parent: Products and applications
-parent: Applications
+nav_order: 4
+has_children: true
+parent: Application areas
 title: Translation and localisation
 description: Machine translation for translation and localisation
 ---

--- a/applications/user-generated-content.md
+++ b/applications/user-generated-content.md
@@ -1,6 +1,6 @@
 ---
-grand_parent: Products and applications
-parent: Applications
+nav_order: 9
+parent: Application areas
 title: User-generated content
 description: Machine translation for user-generated content
 ---

--- a/industry/data-confidentiality.md
+++ b/industry/data-confidentiality.md
@@ -1,6 +1,6 @@
 ---
 nav_order: 13
-parent: Products and applications
+parent: Products
 title: Data confidentiality
 description: Data confidentiality in machine translation
 ---

--- a/industry/products.md
+++ b/industry/products.md
@@ -1,6 +1,6 @@
 ---
 nav_order: 12
-parent: Products and applications
+parent: Products
 title: Products
 description: Machine translation products
 ---

--- a/products-and-applications/apis.md
+++ b/products-and-applications/apis.md
@@ -1,7 +1,7 @@
 ---
 nav_order: 14
 layout: coming_soon
-parent: Products and applications
+parent: Products
 title: APIs
 description: Machine translation APIs
 ---

--- a/products-and-applications/features.md
+++ b/products-and-applications/features.md
@@ -1,7 +1,7 @@
 ---
 layout: coming_soon
 nav_order: 15
-parent: Products and applications
+parent: Products
 title: Features
 description: Machine translation features
 ---

--- a/products-and-applications/products-and-applications.md
+++ b/products-and-applications/products-and-applications.md
@@ -1,10 +1,8 @@
 ---
-nav_order: 10
+nav_order: 11
 has_children: true
-title: Products and applications
-description: Machine translation products and applications
+title: Products
+description: Machine translation products
 ---
-
-Machine translation is applied to multiple areas.
 
 There is a growing set of machine translation products on the market.

--- a/products-and-applications/tms-integrations.md
+++ b/products-and-applications/tms-integrations.md
@@ -1,7 +1,7 @@
 ---
 layout: coming_soon
 nav_order: 16
-parent: Products and applications
+parent: Products
 title: CAT/TMS integrations
 description: Machine translation integration in translation software
 ---

--- a/workflows/hybrid-translation.md
+++ b/workflows/hybrid-translation.md
@@ -1,7 +1,7 @@
 ---
 nav_order: 2
-grand_parent: Products and applications
-parent: Human translation workflows
+grand_parent: Application areas
+parent: Translation and localisation
 title: Hybrid translation
 description: Workflow with both human translations and pure machine translations
 ---

--- a/workflows/post-editing.md
+++ b/workflows/post-editing.md
@@ -1,7 +1,7 @@
 ---
 nav_order: 1
-grand_parent: Products and applications
-parent: Human translation workflows
+grand_parent: Application areas
+parent: Translation and localisation
 title: Post-editing (human translation)
 description: Workflow for human correction of machine translation
 ---

--- a/workflows/workflows.md
+++ b/workflows/workflows.md
@@ -1,7 +1,9 @@
 ---
-nav_order: 17
+nav_order: 5
 has_children: true
-parent: Products and applications
+published: false
+grand_parent: Application areas
+parent: Translation and localisation
 title: Human translation workflows
 description: Human-machine translation workflows
 ---


### PR DESCRIPTION
# Description

- Makes `Applications` a top-level directory. Renames it to `Application areas`.
- Renames `Products and applications` as `Products`.
- Rearranges articles within `Application areas`.
- Makes `Translation and localisation` a parent article, and `Post-editing` and `Hybrid translation` its children.

## Type of PR

- Rearrangement of directories and articles.


### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
- [x] I have made sure that the URL is not already in use.
- [x] I have cross-linked relevant articles.
- [x] I have used the UK spelling.
- [x] I have kept consistency with the structure of sister articles in the same directory.