### PR TITLE
Update libraries and frameworks article

### DIFF
--- a/building/libraries-frameworks.md
+++ b/building/libraries-frameworks.md
@@ -23,7 +23,7 @@ description: Libraries and frameworks for building machine translation systems
 | [**Simple Transformers**](https://github.com/ThilinaRajapakse/simpletransformers) | PyTorch / TensorFlow, based on [HuggingFace Transformers](https://github.com/huggingface/transformers) | Python | &#10004; |
 | [**Sockeye**](https://github.com/awslabs/sockeye) | PyTorch / [MXNet](https://github.com/apache/incubator-mxnet) | Python | &#10004; |
 | [**Tensor2Tensor**](https://github.com/tensorflow/tensor2tensor) | TensorFlow | Python | |
-| [**Trax Transformer**](https://github.com/google/trax) | TensorFlow | Python | |
+| [**Trax**](https://github.com/google/trax) | TensorFlow | Python | &#10004; |
 | [**THUMT**](https://github.com/THUNLP-MT/THUMT) | PyTorch / TensorFlow | Python | |
 
 ### References

--- a/building/libraries-frameworks.md
+++ b/building/libraries-frameworks.md
@@ -6,28 +6,25 @@ description: Libraries and frameworks for building machine translation systems
 
 ## Neural machine translation
 
-| Machine translation library or framework | Machine learning framework | Programming language |
-| --- | --- | --- |
-| [**Argos Translate**](https://github.com/argosopentech/argos-translate) | [PyTorch](https://github.com/pytorch/pytorch) | Python |
-| [**Attention is all you need**](https://github.com/jadore801120/attention-is-all-you-need-pytorch) | PyTorch | Python |
-| [**Fairseq**](https://github.com/pytorch/fairseq) |	PyTorch | Python |
-| [**Marian NMT**](https://github.com/marian-nmt/marian) |  | C++ |
-| [**ModernMT**](https://github.com/modernmt/modernmt) | PyTorch, based on [Fairseq](https://github.com/pytorch/fairseq) | Java, Python |
-| [**Nematus**](https://github.com/EdinburghNLP/nematus) | [TensorFlow](https://github.com/tensorflow/tensorflow) | Python |
-| [**NeuralMonkey**](https://github.com/ufal/neuralmonkey) | TensorFlow | Python |
-| [**NiuTrans.NMT**](https://github.com/NiuTrans/NiuTrans.NMT) | [NiuTensor](https://github.com/NiuTrans/NiuTensor) | C++ |
-| [**NMT-Keras**](https://github.com/lvapeab/nmt-keras) | TensorFlow | Python |
-| [**Lingvo**](https://github.com/tensorflow/lingvo) | TensorFlow | Python |
-| [**OpenNMT-py**](https://github.com/OpenNMT/OpenNMT-py) | PyTorch | Python |
-| [**OpenNMT-tf**](https://github.com/OpenNMT/OpenNMT-tf) | TensorFlow | Python |
-| [**seq2seq**](https://github.com/google/seq2seq) | TensorFlow | Python |
-| [**Sockeye**](https://github.com/awslabs/sockeye) | [MXNet](https://github.com/apache/incubator-mxnet) | Python |
-| [**Tensor2Tensor**](https://github.com/tensorflow/tensor2tensor) | TensorFlow | Python |
-| [**Trax Transformer**](https://github.com/google/trax) | Tensorflow | Python |
-| [**THUMT-PyTorch**](https://github.com/THUNLP-MT/THUMT) | PyTorch | Python |
-| [**THUMT-TensorFlow**](https://github.com/THUNLP-MT/THUMT/tree/tensorflow) | TensorFlow | Python |
-| [**xnmt**](https://github.com/neulab/xnmt) | [Dynet](https://github.com/clab/dynet) | Python |
-
+| Machine translation library or framework | Machine learning framework | Programming language | Commonly used in research |
+| --- | --- | --- | :-: |
+| [**Argos Translate**](https://github.com/argosopentech/argos-translate) | [PyTorch](https://github.com/pytorch/pytorch) | Python | |
+| [**Attention is all you need**](https://github.com/jadore801120/attention-is-all-you-need-pytorch) | PyTorch | Python | |
+| [**Fairseq**](https://github.com/pytorch/fairseq) |	PyTorch | Python | &#10004; |
+| [**HuggingFace Transformers**](https://github.com/huggingface/transformers) |	PyTorch / [TensorFlow](https://github.com/tensorflow/tensorflow) | Python | &#10004; |
+| [**Joey NMT**](https://github.com/joeynmt/joeynmt) |	PyTorch | Python | |
+| [**Marian NMT**](https://github.com/marian-nmt/marian) |  | C++ | &#10004; |
+| [**ModernMT**](https://github.com/modernmt/modernmt) | PyTorch, based on [Fairseq](https://github.com/pytorch/fairseq) | Java, Python | |
+| [**Nematus**](https://github.com/EdinburghNLP/nematus) | TensorFlow | Python | |
+| [**NiuTrans.NMT**](https://github.com/NiuTrans/NiuTrans.NMT) | [NiuTensor](https://github.com/NiuTrans/NiuTensor) | C++ | |
+| [**Lingvo**](https://github.com/tensorflow/lingvo) | TensorFlow | Python | |
+| [**OpenNMT-py**](https://github.com/OpenNMT/OpenNMT-py) | PyTorch | Python | &#10004; |
+| [**OpenNMT-tf**](https://github.com/OpenNMT/OpenNMT-tf) | TensorFlow | Python | &#10004; |
+| [**Simple Transformers**](https://github.com/ThilinaRajapakse/simpletransformers) | PyTorch / TensorFlow, based on [HuggingFace Transformers](https://github.com/huggingface/transformers) | Python | &#10004; |
+| [**Sockeye**](https://github.com/awslabs/sockeye) | PyTorch / [MXNet](https://github.com/apache/incubator-mxnet) | Python | &#10004; |
+| [**Tensor2Tensor**](https://github.com/tensorflow/tensor2tensor) | TensorFlow | Python | |
+| [**Trax Transformer**](https://github.com/google/trax) | TensorFlow | Python | |
+| [**THUMT**](https://github.com/THUNLP-MT/THUMT) | PyTorch / TensorFlow | Python | |
 
 ### References
 


### PR DESCRIPTION
# Description

This PR updates the libraries and frameworks article.

Specifically:

- Adds HF Transformers, Simple Transformers and Joey NMT frameworks. HF Transformers & Simple Transformers can be used to train basic Transformer models, as well as train/fine-tune mT5 and mBART models which can be used as a base for NMT models. They also provide conversion scripts for Marian NMT models to be used directly from the Transformers framework. Joey NMT is a minimalist framework for educational purposes, so it may be useful for students who want to learn the foundations of NMT.
- Merges THUMT PyTorch and THUMT TensorFlow into a single entry. They share a single repository, so I believe there is no need for two separate entries.
- Removes frameworks that have not been in active development for a few years (NeuralMonkey, NMT Keras, seq2seq, xnmt).
- Adds column with checkbox to highlight frameworks that are most commonly used in research.

Also, I wondered what to do with the Google Tensor2Tensor framework, because the official repository states that it is deprecated and encourage to use their Trax framework instead, but decided to leave it for now.

## Type of PR

- Edits _[Libraries and frameworks]_

### Checklist:

- [X] I have read the [contributing guidelines](contributing.md).
- [X] I have followed the [style guide](http://machinetranslate.org/style).
- [X] I have made sure that the URL is not already in use.
- [X] I have cross-linked relevant articles.
- [X] I have used the UK spelling.
- [X] I have kept consistency with the structure of sister articles in the same directory.
