### PR TITLE
Add past mt marathons

### DIFF
--- a/events/events.md
+++ b/events/events.md
@@ -26,6 +26,7 @@ featured: true
 | December | **AAMT 2022** | |
 | 12 October | [**LoResMT 2022**](loresmt2022.md) | online |
 | 12 September | [**AMTA 2022**](amta2022.md) | Orlando, United States |
+| 5-10 September | [MT Marathon](https://ufal.mff.cuni.cz/mtm22/) | Prague, Czech Republic |
 | 2 July | [**NeTTT Conference**](nettt2022.md) | Rhodes, Greece |
 | 1 June | [**EAMT 2022**](eamt2022.md) | Ghent, Belgium |
 | 26 May | [**IWSLT 2022**](iwslt2022.md) | Dublin, Ireland |
@@ -37,6 +38,7 @@ featured: true
 | 1 March | [Simultaneous Speech-to-speech Translation with Transformer-based Incremental ASR, MT, and TTS](https://iwslt.org/lectures/) | online |
 | 3 February | [Machine Translation and Language Learning: What the Research Tells Us](/files/mt-and-language-learning.pdf) | online |
 | 28 January | [TQ2022](tq2022.md) | online |
+
 
 
 ## 2021
@@ -71,7 +73,7 @@ featured: true
 | ---- | ---- | ---- |
 | 19 November | [AAMT 2019](aamt2019.md) | Tokyo, Japan |
 | 28 October | [Machine Translation Meetup 5](zurich-5.md) | Zurich, Switzerland |
-| 26-31 August | [MTM](mtm2019.md) | Edinburgh, Scotland |
+| 26-31 August | [MT Marathon](mtm2019.md) | Edinburgh, Scotland |
 | 20 August | LoResMT 2019 | Dublin, Ireland |
 | 20 August | PSLT2019 | Dublin, Ireland |
 | 19-23 August | [MT Summit 2019](mtsummit2019.md) | Dublin, Ireland |
@@ -85,8 +87,9 @@ featured: true
 | ---- | ---- | ---- |
 | 31 October-1 November | [**WMT18**](wmt18.md) | Brussels, Belgium |
 | 22 October | [Machine Translation Meetup 2](zurich-2.md) | Zurich, Switzerland |
+| 3-8 September | [MT Marathon](https://ufal.mff.cuni.cz/mtm18/) | Prague, Czech Republic |
 | 28-30 May | EAMT 2018 | Alicante, Spain |
-| 21-25 May | -thon in the Americas | Pittsburgh, United States |
+| 21-25 May | MT Marathon in the Americas | Pittsburgh, United States |
 | 19 April | [Machine Translation Meetup 1](zurich-1.md) | Zurich, Switzerland |
 | 21 March | LoResMT 2018 | Massachusetts, United States |
 | 17-21 March | AMTA 2018 | Massachusetts, United States |
@@ -107,7 +110,7 @@ featured: true
 |  |  |  |
 | ---- | ---- | ---- |
 | 28 October-1 November | AMTA 2016 | Texas, United States |
-| 12-17 September | MT Marathon | Prague, Czech Republic |
+| 12-17 September | [MT Marathon](https://ufal.mff.cuni.cz/mtm16/) | Prague, Czech Republic |
 | 11-12 August | [**WMT16**](wmt16.md) | Berlin, Germany |
 | 30 May-1 June | EAMT 2016 | Riga, Latvia |
 | 16-21 May | MT Marathon in the Americas | Notre Dame, United States |
@@ -138,7 +141,7 @@ featured: true
 
 |  |  |  |
 | ---- | ---- | ---- |
-| 9-14 September | MT Marathon | Prague, Czech Republic |
+| 9-14 September | [MT Marathon](https://ufal.mff.cuni.cz/mtm13/) | Prague, Czech Republic |
 | 2 September | WPTP 2013 | Nice, France |
 | 2-6 September | MT Summit XIV | Nice, France |
 | 8-9 August | **WMT13** | Sofia, Bulgaria |
@@ -177,7 +180,7 @@ featured: true
 | ---- | ---- | ---- |
 | 30-31 March | **WMT09** | Athens, Greece |
 | 14-15 May | EAMT 2009 | Barcelona, Spain |
-| 26-30 January | MT Marathon | Prague, Czech Republic |
+| 26-30 January | [MT Marathon](https://ufal.mff.cuni.cz/euromatrix/mtmarathon/) | Prague, Czech Republic |
 
 ## 2008
 

--- a/events/events.md
+++ b/events/events.md
@@ -86,6 +86,7 @@ featured: true
 | 31 October-1 November | [**WMT18**](wmt18.md) | Brussels, Belgium |
 | 22 October | [Machine Translation Meetup 2](zurich-2.md) | Zurich, Switzerland |
 | 28-30 May | EAMT 2018 | Alicante, Spain |
+| 21-25 May | -thon in the Americas | Pittsburgh, United States |
 | 19 April | [Machine Translation Meetup 1](zurich-1.md) | Zurich, Switzerland |
 | 21 March | LoResMT 2018 | Massachusetts, United States |
 | 17-21 March | AMTA 2018 | Massachusetts, United States |
@@ -97,15 +98,19 @@ featured: true
 | 22 September | PSLT2017 | Nagoya, Japan |
 | 18-22 September | [MT Summit XVI](mtsummit2017.md) | Nagoya, Japan |
 | 7-8 September | [**WMT17**](wmt17.md) | Copenhagen, Denmark |
+| 28 August-2 September | MT Marathon | Lisbon, Portugal |
 | 29-31 May | EAMT 2017 | Prague, Czech Republic |
+| 22-26 May | MT Marathon in the Americas | Dayton, United States |
 
 ## 2016
 
 |  |  |  |
 | ---- | ---- | ---- |
 | 28 October-1 November | AMTA 2016 | Texas, United States |
+| 12-17 September | MT Marathon | Prague, Czech Republic |
 | 11-12 August | [**WMT16**](wmt16.md) | Berlin, Germany |
 | 30 May-1 June | EAMT 2016 | Riga, Latvia |
+| 16-21 May | MT Marathon in the Americas | Notre Dame, United States |
 
 ## 2015
 
@@ -115,7 +120,9 @@ featured: true
 | 3 November | PSLT2015 | Miami, United States |
 | 30 October-3 November | [MT Summit XV](mtsummit2015.md) | Miami, United States |
 | 17-18 September | [**WMT15**](wmt15.md) | Lisbon, Portugal |
+| 7-12 September | MT Marathon | Prague, Czech Republic |
 | 11-13 May | EAMT 2015 | Antalya, Turkey |
+| 10-15 May | MT Marathon in the Americas | Urbana-Champaigne, United States |
 
 ## 2014
 
@@ -123,6 +130,7 @@ featured: true
 | ---- | ---- | ---- |
 | 26 October | WPTP 2014 | British Columbia, Canada |
 | 22-26 October | AMTA 2014 | British Columbia, Canada |
+| 8-13 September | MT Marathon | Trento, Italy |
 | 26-27 June | **WMT14** | Baltimore, United States |
 | 16-18 June | EAMT 2014 | Dubrovnik, Croatia |
 
@@ -130,6 +138,7 @@ featured: true
 
 |  |  |  |
 | ---- | ---- | ---- |
+| 9-14 September | MT Marathon | Prague, Czech Republic |
 | 2 September | WPTP 2013 | Nice, France |
 | 2-6 September | MT Summit XIV | Nice, France |
 | 8-9 August | **WMT13** | Sofia, Bulgaria |
@@ -140,6 +149,7 @@ featured: true
 | ---- | ---- | ---- |
 | 28 October | WPTP 2012 | California, United States |
 | 28 October-1 November | AMTA 2012 | California, United States |
+| 3-8 September | MT Marathon | Edinburgh, United Kingdom |
 | 7-8 June | **WMT12** | Quebec, Canada |
 | 28-30 May | EAMT 2012 | Trento, Italy |
 
@@ -147,6 +157,7 @@ featured: true
 
 |  |  |  |
 | ---- | ---- | ---- |
+| 5-10 September | MT Marathon | Trento, Italy |
 | 30-31 July | **WMT11** | Edinburgh, United Kingdom  |
 | 30-31 May | EAMT 2011 | Leuven, Belgium |
 
@@ -155,8 +166,10 @@ featured: true
 |  |  |  |
 | ---- | ---- | ---- |
 | 31 October-4 November 4 | AMTA 2010 | Colorado, United States |
+| 13-18 September | MT Marathon | Le Mans, France |
 | 15-16 July | **WMT11** | Uppsala, Sweden |
 | 27-28 May | EAMT 2010 | Saint Raphaël, France |
+| 25-30 January | MT Marathon | Dublin, Ireland |
 
 ## 2009
 
@@ -164,6 +177,7 @@ featured: true
 | ---- | ---- | ---- |
 | 30-31 March | **WMT09** | Athens, Greece |
 | 14-15 May | EAMT 2009 | Barcelona, Spain |
+| 26-30 January | MT Marathon | Prague, Czech Republic |
 
 ## 2008
 
@@ -172,6 +186,7 @@ featured: true
 | 21-25 October | AMTA 2008 | Hawaii, United States |
 | 22-23 September | EAMT 2008 | Hamburg, Germany |
 | 19 June | **WMT08** | Ohio, United States |
+| 12-20 May | MT Marathon | Berlin, Germany |
 
 ## 2007
 
@@ -180,6 +195,7 @@ featured: true
 | 10-14 September | MT Summit 2007 | Copenhagen, Denmark |
 | 23 June | **WMT07** | Prague, Czech Republic |
 | 26 April | AMTA 2007 - “Syntax and structure in statistical translation” | New York, United States |
+| 16-20 April | MT Marathon | Edinburgh, United Kingdom |
 
 ## 2006
 

--- a/events/events.md
+++ b/events/events.md
@@ -91,7 +91,7 @@ featured: true
 | 22 October | [Machine Translation Meetup 2](zurich-2.md) | Zurich, Switzerland |
 | 3-8 September | [MT Marathon](https://ufal.mff.cuni.cz/mtm18/) | Prague, Czech Republic |
 | 28-30 May | EAMT 2018 | Alicante, Spain |
-| 21-25 May | MT Marathon in the Americas | Pittsburgh, United States |
+| 21-25 May | MT Marathon in the Americas | Pittsburgh, Pennsylvania |
 | 19 April | [Machine Translation Meetup 1](zurich-1.md) | Zurich, Switzerland |
 | 21 March | LoResMT 2018 | Boston, Massachusetts |
 | 17-21 March | AMTA 2018 | Boston, Massachusetts |
@@ -105,21 +105,17 @@ featured: true
 | 7-8 September | [**WMT17**](wmt17.md) | Copenhagen, Denmark |
 | 28 August-2 September | MT Marathon | Lisbon, Portugal |
 | 29-31 May | EAMT 2017 | Prague, Czech Republic |
-| 22-26 May | MT Marathon in the Americas | Dayton, United States |
+| 22-26 May | MT Marathon in the Americas | Dayton, Ohio |
 
 ## 2016
 
 |  |  |  |
 | ---- | ---- | ---- |
-<<<<<<< HEAD
-| 28 October-1 November | AMTA 2016 | Texas, United States |
-| 12-17 September | [MT Marathon](https://ufal.mff.cuni.cz/mtm16/) | Prague, Czech Republic |
-=======
 | 28 October-1 November | AMTA 2016 | Austin, Texas |
->>>>>>> master
+| 12-17 September | [MT Marathon](https://ufal.mff.cuni.cz/mtm16/) | Prague, Czech Republic |
 | 11-12 August | [**WMT16**](wmt16.md) | Berlin, Germany |
 | 30 May-1 June | EAMT 2016 | Riga, Latvia |
-| 16-21 May | MT Marathon in the Americas | Notre Dame, United States |
+| 16-21 May | MT Marathon in the Americas | Notre Dame, Indiana |
 
 ## 2015
 
@@ -131,22 +127,16 @@ featured: true
 | 17-18 September | [**WMT15**](wmt15.md) | Lisbon, Portugal |
 | 7-12 September | MT Marathon | Prague, Czech Republic |
 | 11-13 May | EAMT 2015 | Antalya, Turkey |
-| 10-15 May | MT Marathon in the Americas | Urbana-Champaigne, United States |
+| 10-15 May | MT Marathon in the Americas | Urbana-Champaigne, Illinois |
 
 ## 2014
 
 |  |  |  |
 | ---- | ---- | ---- |
-<<<<<<< HEAD
-| 26 October | WPTP 2014 | British Columbia, Canada |
-| 22-26 October | AMTA 2014 | British Columbia, Canada |
-| 8-13 September | MT Marathon | Trento, Italy |
-| 26-27 June | **WMT14** | Baltimore, United States |
-=======
 | 26 October | WPTP 2014 | Vancouver, Canada |
 | 22-26 October | AMTA 2014 | Vancouver, Canada |
+| 8-13 September | MT Marathon | Trento, Italy |
 | 26-27 June | **WMT14** | Baltimore, Maryland |
->>>>>>> master
 | 16-18 June | EAMT 2014 | Dubrovnik, Croatia |
 
 ## 2013
@@ -162,16 +152,10 @@ featured: true
 
 |  |  |  |
 | ---- | ---- | ---- |
-<<<<<<< HEAD
-| 28 October | WPTP 2012 | California, United States |
-| 28 October-1 November | AMTA 2012 | California, United States |
-| 3-8 September | MT Marathon | Edinburgh, United Kingdom |
-| 7-8 June | **WMT12** | Quebec, Canada |
-=======
 | 28 October | WPTP 2012 | San Diego, California |
 | 28 October-1 November | AMTA 2012 | San Diego, California |
+| 3-8 September | MT Marathon | Edinburgh, United Kingdom |
 | 7-8 June | **WMT12** | Montreal, Quebec |
->>>>>>> master
 | 28-30 May | EAMT 2012 | Trento, Italy |
 
 ## 2011
@@ -186,12 +170,8 @@ featured: true
 
 |  |  |  |
 | ---- | ---- | ---- |
-<<<<<<< HEAD
-| 31 October-4 November 4 | AMTA 2010 | Colorado, United States |
-| 13-18 September | MT Marathon | Le Mans, France |
-=======
 | 31 October-4 November 4 | AMTA 2010 | Denver, Colorado |
->>>>>>> master
+| 13-18 September | MT Marathon | Le Mans, France |
 | 15-16 July | **WMT11** | Uppsala, Sweden |
 | 27-28 May | EAMT 2010 | Saint Raphaël, France |
 | 25-30 January | MT Marathon | Dublin, Ireland |
@@ -210,12 +190,8 @@ featured: true
 | ---- | ---- | ---- |
 | 21-25 October | AMTA 2008 | Waikiki, Hawaii |
 | 22-23 September | EAMT 2008 | Hamburg, Germany |
-<<<<<<< HEAD
-| 19 June | **WMT08** | Ohio, United States |
-| 12-20 May | MT Marathon | Berlin, Germany |
-=======
 | 19 June | **WMT08** | Columbus, Ohio |
->>>>>>> master
+| 12-20 May | MT Marathon | Berlin, Germany |
 
 ## 2007
 
@@ -223,12 +199,8 @@ featured: true
 | ---- | ---- | ---- |
 | 10-14 September | MT Summit 2007 | Copenhagen, Denmark |
 | 23 June | **WMT07** | Prague, Czech Republic |
-<<<<<<< HEAD
-| 26 April | AMTA 2007 - “Syntax and structure in statistical translation” | New York, United States |
-| 16-20 April | MT Marathon | Edinburgh, United Kingdom |
-=======
 | 26 April | AMTA 2007 - “Syntax and structure in statistical translation” | Rochester, New York |
->>>>>>> master
+| 16-20 April | MT Marathon | Edinburgh, United Kingdom |
 
 ## 2006
 


### PR DESCRIPTION
# Description

Adds past (and one future) MT Marathons. Not all MT Marathons have working websites anymore (we're working on that) but those that do were added.

## Type of PR

Edits __events__.

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
- [x] I have made sure that the URL is not already in use.
- [x] I have cross-linked relevant articles.
- [x] I have used the UK spelling.
- [x] I have kept consistency with the structure of sister articles in the same directory.
