### PR TITLE
add personal webpages

### DIFF
--- a/people/andy-way.md
+++ b/people/andy-way.md
@@ -6,3 +6,5 @@ layout: coming_soon
 title: Andy Way
 description:
 ---
+
+[Personal webpage](https://www.computing.dcu.ie/~away/).

--- a/people/jaime-carbonell.md
+++ b/people/jaime-carbonell.md
@@ -6,3 +6,5 @@ layout: coming_soon
 title: Jaime Carbonell
 description:
 ---
+
+[Personal webpage](http://www.cs.cmu.edu/~jgc/).

--- a/people/martin-popel.md
+++ b/people/martin-popel.md
@@ -6,3 +6,5 @@ layout: coming_soon
 title: Martin Popel
 description:
 ---
+
+[Personal webpage](https://ufal.mff.cuni.cz/martin-popel).

--- a/people/matt-post.md
+++ b/people/matt-post.md
@@ -1,0 +1,10 @@
+---
+grand_parent: More
+parent: People
+nav_order: 20
+layout: coming_soon
+title: Matt Post
+description:
+---
+
+[Personal webpage](https://waypost.net/).

--- a/people/ondrej-bojar.md
+++ b/people/ondrej-bojar.md
@@ -19,3 +19,5 @@ He co-authored [Moses](http://www2.statmt.org/moses/), a system for statistical 
 - [Bergamot](https://browser.mt/): browser-based machine translation
 - [ELITR](https://elitr.eu/): simultaneous translation of European languages
 - [CzEng](https://ufal.mff.cuni.cz/czeng): large Czech-English parallel corpus
+
+[Personal webpage](https://www1.cuni.cz/~obo/).

--- a/people/philipp-koehn.md
+++ b/people/philipp-koehn.md
@@ -20,3 +20,5 @@ His early contributions include:
 He was a professor at the University of Edinburgh and then Johns Hopkins University and Chief Scientist at [Omniscien Technologies](/../industry/companies.md#omniscien-technologies).
 
 In 2021, he joined Facebook AI as a Research Scientist.
+
+[Personal webpage](https://www.cs.jhu.edu/~phi/).


### PR DESCRIPTION
# Description

Related to  #247, this PR adds a few personal links (some were on request). Some people have multiple personal pages and in that case I tried to use the most "evergreen" one, which is usually the one they maintain themselves or that which is listed in their Google Scholar. I skipped multiple people because I don't know much about them and was unsure which to choose.

## Type of PR

- Edits `people/` by adding personal links where available. 

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
- [x] I have made sure that the URL is not already in use.
- [x] I have cross-linked relevant articles.
- [x] I have used the UK spelling.
- [x] I have kept consistency with the structure of sister articles in the same directory.
