### PR TITLE
Change titles in "Parallel data"

### DIFF
--- a/customisation/parallel-data.md
+++ b/customisation/parallel-data.md
@@ -6,18 +6,18 @@ description: Parallel data for training machine translation
 featured: true
 ---
 
-**Parallel data** or **parallel corpora** are datasets of **translation pairs** - sentences and their translations.
+**Parallel data** or **parallel corpora** are data sets of **translation pairs** - sentences and their translations.
 They are used to train and test machine translation models.
 
 | Original | Translation |
 | ----------- | ----------- |
 | File | Archivo |
 
-Parallel datasets can include translations for one or more language pairs, and be directioned or directionless.
+Parallel data sets can include translations for one or more language pairs, and be directioned or directionless.
 
 ### Creation
 
-Parallel datasets can be created manually, automatically, or created synthetically from monolingual data.
+Parallel data sets can be created manually, automatically, or created synthetically from monolingual data.
 - Human translation
 - Human [post-editing](../workflows/post-editing.md)
 - [Crawling](crawling.md)
@@ -39,7 +39,7 @@ Parallel data errors can be solved via [filtering](filtering.md).
 
 ### Open data sets
 
-Many of the largest datasets are publicly available.
+Many of the largest data sets are publicly available.
 
 | Name | Type |
 | ---- | ---- |

--- a/customisation/parallel-data.md
+++ b/customisation/parallel-data.md
@@ -6,8 +6,6 @@ description: Parallel data for training machine translation
 featured: true
 ---
 
-# Parallel data
-
 **Parallel data** or **parallel corpora** are datasets of **translation pairs** - sentences and their translations.
 They are used to train and test machine translation models.
 
@@ -17,7 +15,7 @@ They are used to train and test machine translation models.
 
 Parallel datasets can include translations for one or more language pairs, and be directioned or directionless.
 
-### Parallel data creation
+### Creation
 
 Parallel datasets can be created manually, automatically, or created synthetically from monolingual data.
 - Human translation
@@ -39,7 +37,9 @@ Parallel data can have errors, like misaligned sentences, bad sentence segmentat
 Errors in parallel data are challenging because they affect the quality of the machine translation output.
 Parallel data errors can be solved via [filtering](filtering.md).
 
-### Public parallel data
+### Open data sets
+
+Many of the largest datasets are publicly available.
 
 | Name | Type |
 | ---- | ---- |


### PR DESCRIPTION
- Remove the main title - it's autogenerated at the top of the article anyway, so now it's repeated
- Remove "parallel data" from titles, it's implied (hence why we don't say "Parallel data challenges")
