### PR TITLE
Update wmt11.md

### DIFF
--- a/events/wmt11.md
+++ b/events/wmt11.md
@@ -2,7 +2,7 @@
 parent: Events
 title: WMT11
 description: Workshop on Machine Translation
-location: Edinburgh, UK
+location: Edinburgh, United Kingdom
 name: WMT11
 startDate: 2011-07-30
 
@@ -17,7 +17,7 @@ seo:
 
   location:
     type: PostalAddress
-    addressCountry: UK
+    addressCountry: United Kingdom
     addressLocality: Edinburgh
 
   organizer:
@@ -25,124 +25,126 @@ seo:
     url: https://www.statmt.org/wmt11/
 ---
 
-The **Sixth Workshop on Machine Translation** (**WMT11**) took place from 30 July to 31 July, 2011, in Edinburgh, UK.
+The **Sixth Workshop on Machine Translation** (**WMT11**) took place from 30 July to 31 July, 2011, in Edinburgh, United Kingdom.
 
-[statmt.org/wmt11/program.html](https://www.statmt.org/wmt11/program.html)
+[statmt.org/wmt11/program.html](https://statmt.org/wmt11/program.html)
 
 {% include collapsible_toc.html %}
 
 ## Tasks
 
-- [Translation](https://statmt.org/wmt11/translation-task.html)
-- [Featured translation](https://statmt.org/wmt11/featured-translation-task.html)
-- [System combination](https://statmt.org/wmt11/system-combination-task.html)
-- [Evaluation](https://statmt.org/wmt11/evaluation-task.html)
+- [Translation](https://www.statmt.org/wmt11/translation-task.html)
+- [Featured translation](https://www.statmt.org/wmt11/featured-translation-task.html)
+- [System combination](https://www.statmt.org/wmt11/system-combination-task.html)
+- [Evaluation](https://www.statmt.org/wmt11/evaluation-task.html)
 - [Tunable metrics](https://www.statmt.org/wmt11/tunable-metrics-task.html)
 
 ### Tunable metrics task
 
-The tunable metrics task is an invitation-only shared task at WMT11. 
+The tunable metrics shared task was invitation-only. 
 
 ## Schedule
 
 ### Day 1
 
-Saturday, July 30, 2011
+Saturday, 30 July, 2011
 
 |     |     |
 | --- | --- |
-| 9:00 – 9:25 | **Session 1: Shared Tasks and Evaluation** <br>(Chair: Chris Callison-Burch) <br>[***A Grain of Salt for the WMT Manual Evaluation***](https://statmt.org/wmt11/pdf/WMT01.pdf) <br>Ondrej Bojar, Miloš Ercegovčević, Martin Popel and Omar Zaidan |
-| 9:25 – 9:50 | 	[***A Lightweight Evaluation Framework for Machine Translation Reordering***](https://statmt.org/wmt11/pdf/WMT02.pdf) <br>David Talbot, Hideto Kazawa, Hiroshi Ichikawa, Jason Katz-Brown, Masakazu Seno and Franz Och |
-| 9:50 – 10:30 | [***Findings of the 2011 Workshop on Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT03.pdf) <br>Chris Callison-Burch, Philipp Koehn, Christof Monz and Omar Zaidan
+| 09:00 – 09:25 | **Session 1: Shared Tasks and Evaluation** <br>Chair: Chris Callison-Burch <br>[***A Grain of Salt for the WMT Manual Evaluation***](https://www.aclanthology.org/W11-2101.pdf) <br>Ondrej Bojar, Miloš Ercegovčević, Martin Popel, Omar Zaidan |
+| 09:25 – 09:50 | 	[***A Lightweight Evaluation Framework for Machine Translation Reordering***](https://www.aclanthology.org/W11-2102.pdf) <br>David Talbot, Hideto Kazawa, Hiroshi Ichikawa, Jason Katz-Brown, Masakazu Seno, Franz Och |
+| 09:50 – 10:30 | [***Findings of the 2011 Workshop on Statistical Machine Translation***](https://www.aclanthology.org/W11-2103.pdf) <br>Chris Callison-Burch, Philipp Koehn, Christof Monz, Omar Zaidan
 | 10:30 – 11:00 | ☕️ |
 | 11:00 – 12:40 | **Session 2: Shared Metrics and System Combination Tasks** <br>Poster Session Metrics |
-| | [***Evaluate with Confidence Estimation: Machine ranking of translation outputs using grammatical features***](https://statmt.org/wmt11/pdf/WMT04.pdf) <br>Eleftherios Avramidis, Maja Popović, David Vilar and Aljoscha Burchardt |
-| | [***AMBER: A Modified BLEU, Enhanced Ranking Metric***](https://statmt.org/wmt11/pdf/WMT05.pdf) <br>Boxing Chen and Roland Kuhn |
-| | [***TESLA at WMT 2011: Translation Evaluation and Tunable Metric***](https://statmt.org/wmt11/pdf/WMT06.pdf) <br>Daniel Dahlmeier, Chang Liu and Hwee Tou Ng |
-| | [***Meteor 1.3: Automatic Metric for Reliable Optimization and Evaluation of Machine Translation Systems***](https://statmt.org/wmt11/pdf/WMT07.pdf) <br>Michael Denkowski and Alon Lavie |
-| | [***Approximating a Deep-Syntactic Metric for MT Evaluation and Tuning***](https://statmt.org/wmt11/pdf/WMT08.pdf) <br>Matouš Macháček and Ondrej Bojar |
-| | [***Evaluation without references: IBM1 scores as evaluation metrics***](https://statmt.org/wmt11/pdf/WMT09.pdf) <br>Maja Popović, David Vilar, Eleftherios Avramidis and Aljoscha Burchardt |
-| | [***Morphemes and POS tags for n-gram based evaluation metrics***](https://statmt.org/wmt11/pdf/WMT10.pdf) <br>Maja Popović |
-| | [***E-rating Machine Translation***](https://statmt.org/wmt11/pdf/WMT11.pdf) <br>Kristen Parton, Joel Tetreault, Nitin Madnani and Martin Chodorow |
-| | [***TINE: A Metric to Assess MT Adequacy***](https://statmt.org/wmt11/pdf/WMT12.pdf) <br>Miguel Rios, Wilker Aziz and Lucia Specia |
-| | [***Regression and Ranking based Optimisation for Sentence Level MT Evaluation***](https://statmt.org/wmt11/pdf/WMT13.pdf) <br>Xingyi Song and Trevor Cohn |
-| | [***MAISE: A Flexible, Configurable, Extensible Open Source Package for Mass AI System Evaluation***](https://statmt.org/wmt11/pdf/WMT14.pdf) <br>Omar Zaidan |
+| | [***Evaluate with Confidence Estimation: Machine ranking of translation outputs using grammatical features***](https://www.aclanthology.org/W11-2104.pdf) <br>Eleftherios Avramidis, Maja Popović, David Vilar, Aljoscha Burchardt |
+| | [***AMBER: A Modified BLEU, Enhanced Ranking Metric***](https://www.aclanthology.org/W11-2105.pdf) <br>Boxing Chen, Roland Kuhn |
+| | [***TESLA at WMT 2011: Translation Evaluation and Tunable Metric***](https://www.aclanthology.org/W11-2106.pdf) <br>Daniel Dahlmeier, Chang Liu, Hwee Tou Ng |
+| | [***Meteor 1.3: Automatic Metric for Reliable Optimization and Evaluation of Machine Translation Systems***](https://www.aclanthology.org/W11-2107.pdf) <br>Michael Denkowski, Alon Lavie |
+| | [***Approximating a Deep-Syntactic Metric for MT Evaluation and Tuning***](https://www.aclanthology.org/W11-2108.pdf) <br>Matouš Macháček, Ondrej Bojar |
+| | [***Evaluation without references: IBM1 scores as evaluation metrics***](https://www.aclanthology.org/W11-2109.pdf) <br>Maja Popović, David Vilar, Eleftherios Avramidis, Aljoscha Burchardt |
+| | [***Morphemes and POS tags for n-gram based evaluation metrics***](https://www.aclanthology.org/W11-2110.pdf) <br>Maja Popović |
+| | [***E-rating Machine Translation***](https://www.aclanthology.org/W11-2111.pdf) <br>Kristen Parton, Joel Tetreault, Nitin Madnani, Martin Chodorow |
+| | [***TINE: A Metric to Assess MT Adequacy***](https://www.aclanthology.org/W11-2112.pdf) <br>Miguel Rios, Wilker Aziz, Lucia Specia |
+| | [***Regression and Ranking based Optimisation for Sentence Level MT Evaluation***](https://www.aclanthology.org/W11-2113.pdf) <br>Xingyi Song, Trevor Cohn |
+| | [***MAISE: A Flexible, Configurable, Extensible Open Source Package for Mass AI System Evaluation***](https://www.aclanthology.org/W11-2114.pdf) <br>Omar Zaidan |
 | 11:00 – 12:40	| **Poster Session System Combination** |
-| | [***MANY improvements for WMT11***](https://statmt.org/wmt11/pdf/WMT15.pdf) <br>Loïc Barrault |
-| | [***The UPV-PRHLT combination system for WMT 2011***](https://statmt.org/wmt11/pdf/WMT16.pdf) <br>Jesús González-Rubio and Francisco Casacuberta |
-| | [***CMU System Combination in WMT 2011***](https://statmt.org/wmt11/pdf/WMT17.pdf) <br>Kenneth Heafield and Alon Lavie |
-| | [***The RWTH System Combination System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT18.pdf) <br>Gregor Leusch, Markus Freitag and Hermann Ney |
-| | [***Expected BLEU Training for Graphs: BBN System Description for WMT11 System Combination Task***](https://statmt.org/wmt11/pdf/WMT19.pdf) <br>Antti-Veikko Rosti, Bing Zhang, Spyros Matsoukas and Richard Schwartz |
-| | [***The UZH System Combination System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT20.pdf) <br>Rico Sennrich |
-| | [***Description of the JHU System Combination Scheme for WMT 2011***](https://statmt.org/wmt11/pdf/WMT21.pdf) <br>Daguang Xu, Yuan Cao and Damianos Karakos |
+| | [***MANY improvements for WMT11***](https://www.aclanthology.org/W11-2115.pdf) <br>Loïc Barrault |
+| | [***The UPV-PRHLT combination system for WMT 2011***](https://www.aclanthology.org/W11-2116.pdf) <br>Jesús González-Rubio, Francisco Casacuberta |
+| | [***CMU System Combination in WMT 2011***](https://www.aclanthology.org/W11-2117.pdf) <br>Kenneth Heafield, Alon Lavie |
+| | [***The RWTH System Combination System for WMT 2011***](https://www.aclanthology.org/W11-2118.pdf) <br>Gregor Leusch, Markus Freitag, Hermann Ney |
+| | [***Expected BLEU Training for Graphs: BBN System Description for WMT11 System Combination Task***](https://www.aclanthology.org/W11-2119.pdf) <br>Antti-Veikko Rosti, Bing Zhang, Spyros Matsoukas, Richard Schwartz |
+| | [***The UZH System Combination System for WMT 2011***](https://www.aclanthology.org/W11-2120.pdf) <br>Rico Sennrich |
+| | [***Description of the JHU System Combination Scheme for WMT 2011***](https://www.aclanthology.org/W11-2121.pdf) <br>Daguang Xu, Yuan Cao, Damianos Karakos |
 | 12:40 – 14:00 | 🍴 |
-| 14:00 – 14:25 | **Session 3: Language Models and Document Alignment** <br>(Chair: David Talbot) <br>[***Multiple-stream Language Models for Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT22.pdf) <br>Abby Levenberg, Miles Osborne and David Matthews |
-| 14:25 – 14:50 | [***KenLM: Faster and Smaller Language Model Queries***](https://statmt.org/wmt11/pdf/WMT23.pdf) <br>Kenneth Heafield |
-| 14:50 – 15:15	| [***Wider Context by Using Bilingual Language Models in Machine Translation***](https://statmt.org/wmt11/pdf/WMT24.pdf) <br>Jan Niehues, Teresa Herrmann, Stephan Vogel and Alex Waibel |
-| 15:15 – 15:40	| [***A Minimally Supervised Approach for Detecting and Ranking Document Translation Pairs***](https://statmt.org/wmt11/pdf/WMT25.pdf) <br>Kriste Krstovski and David A. Smith |
+| 14:00 – 14:25 | **Session 3: Language Models and Document Alignment** <br>Chair: David Talbot <br>[***Multiple-stream Language Models for Statistical Machine Translation***](https://www.aclanthology.org/W11-2122.pdf) <br>Abby Levenberg, Miles Osborne, David Matthews |
+| 14:25 – 14:50 | [***KenLM: Faster and Smaller Language Model Queries***](https://www.aclanthology.org/W11-2123.pdf) <br>Kenneth Heafield |
+| 14:50 – 15:15	| [***Wider Context by Using Bilingual Language Models in Machine Translation***](https://www.aclanthology.org/W11-2124.pdf) <br>Jan Niehues, Teresa Herrmann, Stephan Vogel, Alex Waibel |
+| 15:15 – 15:40	| [***A Minimally Supervised Approach for Detecting and Ranking Document Translation Pairs***](https://www.aclanthology.org/W11-2125.pdf) <br>Kriste Krstovski, David A. Smith |
 | 15:40 – 16:10	| ☕️ |
-| 16:10 – 16:35	| **Session 4: Syntax and Semantics** <br>(Chair: Michel Galley) <br>[***Agreement Constraints for Statistical Machine Translation into German***](https://statmt.org/wmt11/pdf/WMT26.pdf) <br>Philip Williams and Philipp Koehn |
-| 16:35 – 17:00	| [***Fuzzy Syntactic Reordering for Phrase-based Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT27.pdf) <br>Jacob Andreas, Nizar Habash and Owen Rambow |
-| 17:00 – 17:25	| [***Filtering Antonymous, Trend-Contrasting, and Polarity-Dissimilar Distributional Paraphrases for Improving Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT28.pdf) <br>Yuval Marton, Ahmed El Kholy and Nizar Habash |
-| 17:25 – 17:50	| [***Productive Generation of Compound Words in Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT29.pdf) <br>Sara Stymne and Nicola Cancedda |
+| 16:10 – 16:35	| **Session 4: Syntax and Semantics** <br>Chair: Michel Galley <br>[***Agreement Constraints for Statistical Machine Translation into German***](https://www.aclanthology.org/W11-2126.pdf) <br>Philip Williams, Philipp Koehn |
+| 16:35 – 17:00	| [***Fuzzy Syntactic Reordering for Phrase-based Statistical Machine Translation***](https://www.aclanthology.org/W11-2127.pdf) <br>Jacob Andreas, Nizar Habash, Owen Rambow |
+| 17:00 – 17:25	| [***Filtering Antonymous, Trend-Contrasting, and Polarity-Dissimilar Distributional Paraphrases for Improving Statistical Machine Translation***](https://www.aclanthology.org/W11-2128.pdf) <br>Yuval Marton, Ahmed El Kholy, Nizar Habash |
+| 17:25 – 17:50	| [***Productive Generation of Compound Words in Statistical Machine Translation***](https://www.aclanthology.org/W11-2129.pdf) <br>Sara Stymne, Nicola Cancedda |
 
 ### Day 2
 
-Sunday, July 31, 2011
+Sunday, 31 July, 2011
 
 |     |     |
 | --- | --- |
-| 9:00 – 10:25 | **Session 5: Machine Learning and Adaptation** <br>(Chair: Phil Blunsom) <br>[***SampleRank Training for Phrase-Based Machine Translation***](https://statmt.org/wmt11/pdf/WMT30.pdf) <br>Barry Haddow, Abhishek Arun and Philipp Koehn |
-| 9:25 – 10:50 | [***Instance Selection for Machine Translation using Feature Decay Algorithms***](https://statmt.org/wmt11/pdf/WMT31.pdf) <br>Ergun Bicici and Deniz Yuret |
-| 9:50 – 10:15 | [***Investigations on Translation Model Adaptation Using Monolingual Data***](https://statmt.org/wmt11/pdf/WMT32.pdf) <br>Patrik Lambert, Holger Schwenk, Christophe Servan and Sadaf Abdul-Rauf |
-| 10:15 – 10:40	| [***Topic Adaptation for Lecture Translation through Bilingual Latent Semantic Models***](https://statmt.org/wmt11/pdf/WMT33.pdf) <br>Nick Ruiz and Marcello Federico |
+| 09:00 – 10:25 | **Session 5: Machine Learning and Adaptation** <br>Chair: Phil Blunsom <br>[***SampleRank Training for Phrase-Based Machine Translation***](https://www.aclanthology.org/W11-2130.pdf) <br>Barry Haddow, Abhishek Arun, Philipp Koehn |
+| 09:25 – 10:50 | [***Instance Selection for Machine Translation using Feature Decay Algorithms***](https://www.aclanthology.org/W11-2131.pdf) <br>Ergun Bicici, Deniz Yuret |
+| 09:50 – 10:15 | [***Investigations on Translation Model Adaptation Using Monolingual Data***](https://www.aclanthology.org/W11-2132.pdf) <br>Patrik Lambert, Holger Schwenk, Christophe Servan, Sadaf Abdul-Rauf |
+| 10:15 – 10:40	| [***Topic Adaptation for Lecture Translation through Bilingual Latent Semantic Models***](https://www.aclanthology.org/W11-2133.pdf) <br>Nick Ruiz, Marcello Federico |
 | 10:40 – 11:00 | ☕️ |
 | 11:00 – 12:40 | **Session 6: Shared Translation Task** <br>Poster Presentations |
-| | [***Personal Translator at WMT2011***](https://statmt.org/wmt11/pdf/WMT34.pdf) <br>Vera Aleksic and Gregor Thurmair |
-| | [***LIMSI @ WMT11***](https://statmt.org/wmt11/pdf/WMT35.pdf) <br>Alexandre Allauzen, Hélène Bonneau-Maynard, Hai-Son Le, Aurélien Max, Guillaume Wisniewski, François Yvon, Gilles Adda, Josep Maria Crego, Adrien Lardilleux, Thomas Lavergne and Artem Sokolov |
-| | [***Shallow Semantic Trees for SMT***](https://statmt.org/wmt11/pdf/WMT36.pdf) <br>Wilker Aziz, Miguel Rios and Lucia Specia |
-| | [***RegMT System for Machine Translation, System Combination, and Evaluation***](https://statmt.org/wmt11/pdf/WMT37.pdf) <br>Ergun Bicici and Deniz Yuret |
-| | [***Improving Translation Model by Monolingual Data***](https://statmt.org/wmt11/pdf/WMT38.pdf) <br>Ondrej Bojar and Aleš Tamchyna |
-| | [***The CMU-ARK German-English Translation System***](https://statmt.org/wmt11/pdf/WMT39.pdf) <br>Chris Dyer, Kevin Gimpel, Jonathan H. Clark and Noah A. Smith |
-| | [***Noisy SMS Machine Translation in Low-Density Languages***](https://statmt.org/wmt11/pdf/WMT40.pdf) <br>Vladimir Eidelman, Kristy Hollingshead and Philip Resnik |
-| | [***Stochastic Parse Tree Selection for an Existing RBMT System***](https://statmt.org/wmt11/pdf/WMT41.pdf) <br>Christian Federmann and Sabine Hunsicker |
-| | [***Joint WMT Submission of the QUAERO Project***](https://statmt.org/wmt11/pdf/WMT42.pdf) <br>Markus Freitag, Gregor Leusch, Joern Wuebker, Stephan Peitz, Hermann Ney, Teresa Herrmann, Jan Niehues, Alex Waibel, Alexandre Allauzen, Gilles Adda, Josep Maria Crego, Bianka Buschbeck, Tonio Wandmacher and Jean Senellart |
-| | [***CMU Syntax-Based Machine Translation at WMT 2011***](https://statmt.org/wmt11/pdf/WMT43.pdf) <br>Greg Hanneman and Alon Lavie |
-| | [***The Uppsala-FBK systems at WMT 2011***](https://statmt.org/wmt11/pdf/WMT44.pdf) <br>Christian Hardmeier, Jörg Tiedemann, Markus Saers, Marcello Federico and Mathur Prashant |
-| | [***The Karlsruhe Institute of Technology Translation Systems for the WMT 2011***](https://statmt.org/wmt11/pdf/WMT45.pdf) <br>Teresa Herrmann, Mohammed Mediani, Jan Niehues and Alex Waibel |
-| | [***CMU Haitian Creole-English Translation System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT46.pdf) <br>Sanjika Hewavitharana, Nguyen Bach, Qin Gao, Vamshi Ambati and Stephan Vogel |
-| | [***Experiments with word alignment, normalization and clause reordering for SMT between English and German***](https://statmt.org/wmt11/pdf/WMT47.pdf) <br>Maria Holmqvist, Sara Stymne and Lars Ahrenberg |
-| | [***The Value of Monolingual Crowdsourcing in a Real-World Translation Scenario: Simulation using Haitian Creole Emergency SMS Messages***](https://statmt.org/wmt11/pdf/WMT48.pdf) <br>Chang Hu, Philip Resnik, Yakov Kronrod, Vladimir Eidelman, Olivia Buzek and Benjamin B. Bederson |
-| | [***The RWTH Aachen Machine Translation System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT49.pdf) <br>Matthias Huck, Joern Wuebker, Christoph Schmidt, Markus Freitag, Stephan Peitz, Daniel Stein, Arnaud Dagnelies, Saab Mansour, Gregor Leusch and Hermann Ney |
-| | [***ILLC-UvA translation system for EMNLP-WMT 2011***](https://statmt.org/wmt11/pdf/WMT50.pdf) <br>Maxim Khalilov and Khalil Sima’an |
-| | [***UPM system for the translation task***](https://statmt.org/wmt11/pdf/WMT51.pdf) <br>Verónica López-Ludeña and Rubén San-Segundo |
-| | [***Two-step translation with grammatical post-processing***](https://statmt.org/wmt11/pdf/WMT52.pdf) <br>David Mareček, Rudolf Rosa, Petra Galuščáková and Ondrej Bojar |
-| | [***Influence of Parser Choice on Dependency-Based MT***](https://statmt.org/wmt11/pdf/WMT53.pdf) <br>Martin Popel, David Mareček, Nathan Green and Zdenek Zabokrtsky |
-| | [***The LIGA (LIG/LIA) Machine Translation System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT54.pdf) <br>Marion Potet, Raphaël Rubino, Benjamin Lecouteux, Stéphane Huet, Laurent Besacier, Hervé Blanchon and Fabrice Lefèvre |
-| | [***Factored Translation with Unsupervised Word Clusters***](https://statmt.org/wmt11/pdf/WMT55.pdf) <br>Christian Rishj and Anders Sgaard |
-| | [***The BM-I2R Haitian-Créole-to-English translation system description for the WMT 2011 evaluation campaign***](https://statmt.org/wmt11/pdf/WMT56.pdf) <br>Marta R. Costa-jussà and Rafael E. Banchs |
-| | [***The Universitat d'Alacant hybrid machine translation system for WMT 2011***](https://statmt.org/wmt11/pdf/WMT57.pdf) <br>Víctor M. Sánchez-Cartagena, Felipe Sánchez-Martínez and Juan Antonio Pérez-Ortiz |
-| | [***LIUM’s SMT Machine Translation Systems for WMT 2011***](https://statmt.org/wmt11/pdf/WMT58.pdf) <br>Holger Schwenk, Patrik Lambert, Loïc Barrault, Christophe Servan, Sadaf Abdul-Rauf, Haithem Afli and Kashif Shah |
-| | [***Spell Checking Techniques for Replacement of Unknown Words and Data Cleaning for Haitian Creole SMS Translation***](https://statmt.org/wmt11/pdf/WMT59.pdf) <br>Sara Stymne |
-| | [***Joshua 3.0: Syntax-based Machine Translation with the Thrax Grammar Extractor***](https://statmt.org/wmt11/pdf/WMT60.pdf) <br>Jonathan Weese, Juri Ganitkevitch, Chris Callison-Burch, Matt Post and Adam Lopez |
-| | [***DFKI Hybrid Machine Translation System for WMT 2011 - On the Integration of SMT and RBMT***](https://statmt.org/wmt11/pdf/WMT61.pdf) <br>Jia Xu, Hans Uszkoreit, Casey Kennington, David Vilar and Xiaojun Zhang |
-| | [***CEU-UPV English-Spanish system for WMT11***](https://statmt.org/wmt11/pdf/WMT62.pdf) <br>Francisco Zamora-Martinez and Maria Jose Castro-Bleda |
-| | [***Hierarchical Phrase-Based MT at the Charles University for the WMT 2011 Shared Task***](https://statmt.org/wmt11/pdf/WMT63.pdf) <br>Daniel Zeman |
+| | [***Personal Translator at WMT2011***](https://www.aclanthology.org/W11-2134.pdf) <br>Vera Aleksic, Gregor Thurmair |
+| | [***LIMSI @ WMT11***](https://www.aclanthology.org/W11-2135.pdf) <br>Alexandre Allauzen, Hélène Bonneau-Maynard, Hai-Son Le, Aurélien Max, Guillaume Wisniewski, François Yvon, Gilles Adda, Josep Maria Crego, Adrien Lardilleux, Thomas Lavergne, Artem Sokolov |
+| | [***Shallow Semantic Trees for SMT***](https://www.aclanthology.org/W11-2136.pdf) <br>Wilker Aziz, Miguel Rios, Lucia Specia |
+| | [***RegMT System for Machine Translation, System Combination, and Evaluation***](https://www.aclanthology.org/W11-2137.pdf) <br>Ergun Bicici, Deniz Yuret |
+| | [***Improving Translation Model by Monolingual Data***](https://www.aclanthology.org/W11-2138.pdf) <br>Ondrej Bojar, Aleš Tamchyna |
+| | [***The CMU-ARK German-English Translation System***](https://www.aclanthology.org/W11-2139.pdf) <br>Chris Dyer, Kevin Gimpel, Jonathan H. Clark, Noah A. Smith |
+| | [***Noisy SMS Machine Translation in Low-Density Languages***](https://www.aclanthology.org/W11-2140.pdf) <br>Vladimir Eidelman, Kristy Hollingshead, Philip Resnik |
+| | [***Stochastic Parse Tree Selection for an Existing RBMT System***](https://www.aclanthology.org/W11-2141.pdf) <br>Christian Federmann, Sabine Hunsicker |
+| | [***Joint WMT Submission of the QUAERO Project***](https://www.aclanthology.org/W11-2142.pdf) <br>Markus Freitag, Gregor Leusch, Joern Wuebker, Stephan Peitz, Hermann Ney, Teresa Herrmann, Jan Niehues, Alex Waibel, Alexandre Allauzen, Gilles Adda, Josep Maria Crego, Bianka Buschbeck, Tonio Wandmacher, Jean Senellart |
+| | [***CMU Syntax-Based Machine Translation at WMT 2011***](https://www.aclanthology.org/W11-2143.pdf) <br>Greg Hanneman, Alon Lavie |
+| | [***The Uppsala-FBK systems at WMT 2011***](https://www.aclanthology.org/W11-2144.pdf) <br>Christian Hardmeier, Jörg Tiedemann, Markus Saers, Marcello Federico, Mathur Prashant |
+| | [***The Karlsruhe Institute of Technology Translation Systems for the WMT 2011***](https://www.aclanthology.org/W11-2145.pdf) <br>Teresa Herrmann, Mohammed Mediani, Jan Niehues, Alex Waibel |
+| | [***CMU Haitian Creole-English Translation System for WMT 2011***](https://www.aclanthology.org/W11-2146.pdf) <br>Sanjika Hewavitharana, Nguyen Bach, Qin Gao, Vamshi Ambati, Stephan Vogel |
+| | [***Experiments with word alignment, normalization and clause reordering for SMT between English and German***](https://www.aclanthology.org/W11-2147.pdf) <br>Maria Holmqvist, Sara Stymne, Lars Ahrenberg |
+| | [***The Value of Monolingual Crowdsourcing in a Real-World Translation Scenario: Simulation using Haitian Creole Emergency SMS Messages***](https://www.aclanthology.org/W11-2148.pdf) <br>Chang Hu, Philip Resnik, Yakov Kronrod, Vladimir Eidelman, Olivia Buzek, Benjamin B. Bederson |
+| | [***The RWTH Aachen Machine Translation System for WMT 2011***](https://www.aclanthology.org/W11-2149.pdf) <br>Matthias Huck, Joern Wuebker, Christoph Schmidt, Markus Freitag, Stephan Peitz, Daniel Stein, Arnaud Dagnelies, Saab Mansour, Gregor Leusch, Hermann Ney |
+| | [***ILLC-UvA translation system for EMNLP-WMT 2011***](https://www.aclanthology.org/W11-2150.pdf) <br>Maxim Khalilov, Khalil Sima’an |
+| | [***UPM system for the translation task***](https://www.aclanthology.org/W11-2151.pdf) <br>Verónica López-Ludeña, Rubén San-Segundo |
+| | [***Two-step translation with grammatical post-processing***](https://www.aclanthology.org/W11-2152.pdf) <br>David Mareček, Rudolf Rosa, Petra Galuščáková, Ondrej Bojar |
+| | [***Influence of Parser Choice on Dependency-Based MT***](https://www.aclanthology.org/W11-2153.pdf) <br>Martin Popel, David Mareček, Nathan Green, Zdenek Zabokrtsky |
+| | [***The LIGA (LIG/LIA) Machine Translation System for WMT 2011***](https://www.aclanthology.org/W11-2154.pdf) <br>Marion Potet, Raphaël Rubino, Benjamin Lecouteux, Stéphane Huet, Laurent Besacier, Hervé Blanchon, Fabrice Lefèvre |
+| | [***Factored Translation with Unsupervised Word Clusters***](https://www.aclanthology.org/W11-2155.pdf) <br>Christian Rishj, Anders Sgaard |
+| | [***The BM-I2R Haitian-Créole-to-English translation system description for the WMT 2011 evaluation campaign***](https://www.aclanthology.org/W11-2156.pdf) <br>Marta R. Costa-jussà, Rafael E. Banchs |
+| | [***The Universitat d'Alacant hybrid machine translation system for WMT 2011***](https://www.aclanthology.org/W11-2157.pdf) <br>Víctor M. Sánchez-Cartagena, Felipe Sánchez-Martínez, Juan Antonio Pérez-Ortiz |
+| | [***LIUM’s SMT Machine Translation Systems for WMT 2011***](https://www.aclanthology.org/W11-2158.pdf) <br>Holger Schwenk, Patrik Lambert, Loïc Barrault, Christophe Servan, Sadaf Abdul-Rauf, Haithem Afli, Kashif Shah |
+| | [***Spell Checking Techniques for Replacement of Unknown Words and Data Cleaning for Haitian Creole SMS Translation***](https://www.aclanthology.org/W11-2159.pdf) <br>Sara Stymne |
+| | [***Joshua 3.0: Syntax-based Machine Translation with the Thrax Grammar Extractor***](https://www.aclanthology.org/W11-2160.pdf) <br>Jonathan Weese, Juri Ganitkevitch, Chris Callison-Burch, Matt Post, Adam Lopez |
+| | [***DFKI Hybrid Machine Translation System for WMT 2011 - On the Integration of SMT and RBMT***](https://www.aclanthology.org/W11-2161.pdf) <br>Jia Xu, Hans Uszkoreit, Casey Kennington, David Vilar, Xiaojun Zhang |
+| | [***CEU-UPV English-Spanish system for WMT11***](https://www.aclanthology.org/W11-2162.pdf) <br>Francisco Zamora-Martinez, Maria Jose Castro-Bleda |
+| | [***Hierarchical Phrase-Based MT at the Charles University for the WMT 2011 Shared Task***](https://www.aclanthology.org/W11-2163.pdf) <br>Daniel Zeman |
 | 12:40 – 14:00 |	🍴 |
-| 14:00 – 15:40 |	**Invited Talk** <br>[***Crisis MT: Developing A Cookbook for MT in Crisis Situations***](https://statmt.org/wmt11/pdf/WMT64.pdf) <br>William Lewis, Robert Munro and Stephan Vogel |
+| 14:00 – 15:40 |	**Invited Talk** <br>[***Crisis MT: Developing A Cookbook for MT in Crisis Situations***](https://www.aclanthology.org/W11-2164.pdf) <br>William Lewis, Robert Munro, Stephan Vogel |
 | 15:40 – 16:10 | ☕️ |
-| 16:10 – 16:35 | **Session 7: Translation Models** <br>(Chair: Chris Dyer) <br>[***Generative Models of Monolingual and Bilingual Gappy Patterns***](https://statmt.org/wmt11/pdf/WMT65.pdf) <br>Kevin Gimpel and Noah A. Smith |
-| 16:35 – 17:00 | [***Extraction Programs: A Unified Approach to Translation Rule Extraction***](https://statmt.org/wmt11/pdf/WMT66.pdf) <br>Mark Hopkins, Greg Langmead and Tai Vo |
-| 17:00 – 17:25 | [***Bayesian Extraction of Minimal SCFG Rules for Hierarchical Phrase-based Translation***](https://statmt.org/wmt11/pdf/WMT67.pdf) <br>Baskaran Sankaran, Gholamreza Haffari and Anoop Sarkar |
-| 17:25 – 17:50 | [***From n-gram-based to CRF-based Translation Models***](https://statmt.org/wmt11/pdf/WMT68.pdf) <br>Thomas Lavergne, Alexandre Allauzen, Josep Maria Crego and François Yvon |
+| 16:10 – 16:35 | **Session 7: Translation Models** <br>Chair: Chris Dyer <br>[***Generative Models of Monolingual and Bilingual Gappy Patterns***](https://www.aclanthology.org/W11-2165.pdf) <br>Kevin Gimpel, Noah A. Smith |
+| 16:35 – 17:00 | [***Extraction Programs: A Unified Approach to Translation Rule Extraction***](https://www.aclanthology.org/W11-2166.pdf) <br>Mark Hopkins, Greg Langmead, Tai Vo |
+| 17:00 – 17:25 | [***Bayesian Extraction of Minimal SCFG Rules for Hierarchical Phrase-based Translation***](https://www.aclanthology.org/W11-2167.pdf) <br>Baskaran Sankaran, Gholamreza Haffari, Anoop Sarkar |
+| 17:25 – 17:50 | [***From n-gram-based to CRF-based Translation Models***](https://www.aclanthology.org/W11-2168.pdf) <br>Thomas Lavergne, Alexandre Allauzen, Josep Maria Crego, François Yvon |
 
 ## Results
 
-Full results of the shared tasks: [*Findings of the 2011 Workshop on Statistical Machine Translation*](https://statmt.org/wmt11/pdf/WMT03.pdf)
+Full results of the shared tasks: [*Findings of the 2011 Workshop on Statistical Machine Translation*](https://www.statmt.org/wmt11/pdf/WMT03.pdf)
 
 ### News translation
 
-The results are determined through human evaluation featuring [relative ranking](wmt.md#relative-ranking). The winner systems are listed according to their ≥ others score. It shows how frequently the winners were judged to be better than or equal to any other system.
+The results are determined through human evaluation featuring [relative ranking](wmt.md#relative-ranking).
+The winner systems are listed according to their ≥ others score.
+It shows how frequently the winners were judged to be better than or equal to any other system.
 
 #### → English
 

--- a/events/wmt11.md
+++ b/events/wmt11.md
@@ -1,6 +1,164 @@
 ---
 parent: Events
 title: WMT11
-layout: coming_soon
-description: Conference on Machine Translation
+description: Workshop on Machine Translation
+location: Edinburgh, UK
+name: WMT11
+startDate: 2011-07-30
+
+seo:
+  type: Event
+  name: WMT11
+  description: Workshop on Machine Translation
+  startDate: 2011-07-30
+  endDate: 2011-07-31
+  eventAttendanceMode: OfflineEventAttendanceMode
+  eventStatus: EventScheduled
+
+  location:
+    type: PostalAddress
+    addressCountry: UK
+    addressLocality: Edinburgh
+
+  organizer:
+    type: Person
+    url: https://www.statmt.org/wmt11/
 ---
+
+The **Sixth Workshop on Machine Translation** (**WMT11**) took place from 30 July to 31 July, 2011, in Edinburgh, UK.
+
+[statmt.org/wmt11/program.html](https://www.statmt.org/wmt11/program.html)
+
+{% include collapsible_toc.html %}
+
+## Tasks
+
+- [Translation](https://statmt.org/wmt11/translation-task.html)
+- [Featured translation](https://statmt.org/wmt11/featured-translation-task.html)
+- [System combination](https://statmt.org/wmt11/system-combination-task.html)
+- [Evaluation](https://statmt.org/wmt11/evaluation-task.html)
+- [Tunable metrics](https://www.statmt.org/wmt11/tunable-metrics-task.html)
+
+### Tunable metrics task
+
+The tunable metrics task is an invitation-only shared task at WMT11. 
+
+## Schedule
+
+### Day 1
+
+Saturday, July 30, 2011
+
+|     |     |
+| --- | --- |
+| 9:00 – 9:25 | **Session 1: Shared Tasks and Evaluation** <br>(Chair: Chris Callison-Burch) <br>[***A Grain of Salt for the WMT Manual Evaluation***](https://statmt.org/wmt11/pdf/WMT01.pdf) <br>Ondrej Bojar, Miloš Ercegovčević, Martin Popel and Omar Zaidan |
+| 9:25 – 9:50 | 	[***A Lightweight Evaluation Framework for Machine Translation Reordering***](https://statmt.org/wmt11/pdf/WMT02.pdf) <br>David Talbot, Hideto Kazawa, Hiroshi Ichikawa, Jason Katz-Brown, Masakazu Seno and Franz Och |
+| 9:50 – 10:30 | [***Findings of the 2011 Workshop on Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT03.pdf) <br>Chris Callison-Burch, Philipp Koehn, Christof Monz and Omar Zaidan
+| 10:30 – 11:00 | ☕️ |
+| 11:00 – 12:40 | **Session 2: Shared Metrics and System Combination Tasks** <br>Poster Session Metrics |
+| | [***Evaluate with Confidence Estimation: Machine ranking of translation outputs using grammatical features***](https://statmt.org/wmt11/pdf/WMT04.pdf) <br>Eleftherios Avramidis, Maja Popović, David Vilar and Aljoscha Burchardt |
+| | [***AMBER: A Modified BLEU, Enhanced Ranking Metric***](https://statmt.org/wmt11/pdf/WMT05.pdf) <br>Boxing Chen and Roland Kuhn |
+| | [***TESLA at WMT 2011: Translation Evaluation and Tunable Metric***](https://statmt.org/wmt11/pdf/WMT06.pdf) <br>Daniel Dahlmeier, Chang Liu and Hwee Tou Ng |
+| | [***Meteor 1.3: Automatic Metric for Reliable Optimization and Evaluation of Machine Translation Systems***](https://statmt.org/wmt11/pdf/WMT07.pdf) <br>Michael Denkowski and Alon Lavie |
+| | [***Approximating a Deep-Syntactic Metric for MT Evaluation and Tuning***](https://statmt.org/wmt11/pdf/WMT08.pdf) <br>Matouš Macháček and Ondrej Bojar |
+| | [***Evaluation without references: IBM1 scores as evaluation metrics***](https://statmt.org/wmt11/pdf/WMT09.pdf) <br>Maja Popović, David Vilar, Eleftherios Avramidis and Aljoscha Burchardt |
+| | [***Morphemes and POS tags for n-gram based evaluation metrics***](https://statmt.org/wmt11/pdf/WMT10.pdf) <br>Maja Popović |
+| | [***E-rating Machine Translation***](https://statmt.org/wmt11/pdf/WMT11.pdf) <br>Kristen Parton, Joel Tetreault, Nitin Madnani and Martin Chodorow |
+| | [***TINE: A Metric to Assess MT Adequacy***](https://statmt.org/wmt11/pdf/WMT12.pdf) <br>Miguel Rios, Wilker Aziz and Lucia Specia |
+| | [***Regression and Ranking based Optimisation for Sentence Level MT Evaluation***](https://statmt.org/wmt11/pdf/WMT13.pdf) <br>Xingyi Song and Trevor Cohn |
+| | [***MAISE: A Flexible, Configurable, Extensible Open Source Package for Mass AI System Evaluation***](https://statmt.org/wmt11/pdf/WMT14.pdf) <br>Omar Zaidan |
+| 11:00 – 12:40	| **Poster Session System Combination** |
+| | [***MANY improvements for WMT11***](https://statmt.org/wmt11/pdf/WMT15.pdf) <br>Loïc Barrault |
+| | [***The UPV-PRHLT combination system for WMT 2011***](https://statmt.org/wmt11/pdf/WMT16.pdf) <br>Jesús González-Rubio and Francisco Casacuberta |
+| | [***CMU System Combination in WMT 2011***](https://statmt.org/wmt11/pdf/WMT17.pdf) <br>Kenneth Heafield and Alon Lavie |
+| | [***The RWTH System Combination System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT18.pdf) <br>Gregor Leusch, Markus Freitag and Hermann Ney |
+| | [***Expected BLEU Training for Graphs: BBN System Description for WMT11 System Combination Task***](https://statmt.org/wmt11/pdf/WMT19.pdf) <br>Antti-Veikko Rosti, Bing Zhang, Spyros Matsoukas and Richard Schwartz |
+| | [***The UZH System Combination System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT20.pdf) <br>Rico Sennrich |
+| | [***Description of the JHU System Combination Scheme for WMT 2011***](https://statmt.org/wmt11/pdf/WMT21.pdf) <br>Daguang Xu, Yuan Cao and Damianos Karakos |
+| 12:40 – 14:00 | 🍴 |
+| 14:00 – 14:25 | **Session 3: Language Models and Document Alignment** <br>(Chair: David Talbot) <br>[***Multiple-stream Language Models for Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT22.pdf) <br>Abby Levenberg, Miles Osborne and David Matthews |
+| 14:25 – 14:50 | [***KenLM: Faster and Smaller Language Model Queries***](https://statmt.org/wmt11/pdf/WMT23.pdf) <br>Kenneth Heafield |
+| 14:50 – 15:15	| [***Wider Context by Using Bilingual Language Models in Machine Translation***](https://statmt.org/wmt11/pdf/WMT24.pdf) <br>Jan Niehues, Teresa Herrmann, Stephan Vogel and Alex Waibel |
+| 15:15 – 15:40	| [***A Minimally Supervised Approach for Detecting and Ranking Document Translation Pairs***](https://statmt.org/wmt11/pdf/WMT25.pdf) <br>Kriste Krstovski and David A. Smith |
+| 15:40 – 16:10	| ☕️ |
+| 16:10 – 16:35	| **Session 4: Syntax and Semantics** <br>(Chair: Michel Galley) <br>[***Agreement Constraints for Statistical Machine Translation into German***](https://statmt.org/wmt11/pdf/WMT26.pdf) <br>Philip Williams and Philipp Koehn |
+| 16:35 – 17:00	| [***Fuzzy Syntactic Reordering for Phrase-based Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT27.pdf) <br>Jacob Andreas, Nizar Habash and Owen Rambow |
+| 17:00 – 17:25	| [***Filtering Antonymous, Trend-Contrasting, and Polarity-Dissimilar Distributional Paraphrases for Improving Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT28.pdf) <br>Yuval Marton, Ahmed El Kholy and Nizar Habash |
+| 17:25 – 17:50	| [***Productive Generation of Compound Words in Statistical Machine Translation***](https://statmt.org/wmt11/pdf/WMT29.pdf) <br>Sara Stymne and Nicola Cancedda |
+
+### Day 2
+
+Sunday, July 31, 2011
+
+|     |     |
+| --- | --- |
+| 9:00 – 10:25 | **Session 5: Machine Learning and Adaptation** <br>(Chair: Phil Blunsom) <br>[***SampleRank Training for Phrase-Based Machine Translation***](https://statmt.org/wmt11/pdf/WMT30.pdf) <br>Barry Haddow, Abhishek Arun and Philipp Koehn |
+| 9:25 – 10:50 | [***Instance Selection for Machine Translation using Feature Decay Algorithms***](https://statmt.org/wmt11/pdf/WMT31.pdf) <br>Ergun Bicici and Deniz Yuret |
+| 9:50 – 10:15 | [***Investigations on Translation Model Adaptation Using Monolingual Data***](https://statmt.org/wmt11/pdf/WMT32.pdf) <br>Patrik Lambert, Holger Schwenk, Christophe Servan and Sadaf Abdul-Rauf |
+| 10:15 – 10:40	| [***Topic Adaptation for Lecture Translation through Bilingual Latent Semantic Models***](https://statmt.org/wmt11/pdf/WMT33.pdf) <br>Nick Ruiz and Marcello Federico |
+| 10:40 – 11:00 | ☕️ |
+| 11:00 – 12:40 | **Session 6: Shared Translation Task** <br>Poster Presentations |
+| | [***Personal Translator at WMT2011***](https://statmt.org/wmt11/pdf/WMT34.pdf) <br>Vera Aleksic and Gregor Thurmair |
+| | [***LIMSI @ WMT11***](https://statmt.org/wmt11/pdf/WMT35.pdf) <br>Alexandre Allauzen, Hélène Bonneau-Maynard, Hai-Son Le, Aurélien Max, Guillaume Wisniewski, François Yvon, Gilles Adda, Josep Maria Crego, Adrien Lardilleux, Thomas Lavergne and Artem Sokolov |
+| | [***Shallow Semantic Trees for SMT***](https://statmt.org/wmt11/pdf/WMT36.pdf) <br>Wilker Aziz, Miguel Rios and Lucia Specia |
+| | [***RegMT System for Machine Translation, System Combination, and Evaluation***](https://statmt.org/wmt11/pdf/WMT37.pdf) <br>Ergun Bicici and Deniz Yuret |
+| | [***Improving Translation Model by Monolingual Data***](https://statmt.org/wmt11/pdf/WMT38.pdf) <br>Ondrej Bojar and Aleš Tamchyna |
+| | [***The CMU-ARK German-English Translation System***](https://statmt.org/wmt11/pdf/WMT39.pdf) <br>Chris Dyer, Kevin Gimpel, Jonathan H. Clark and Noah A. Smith |
+| | [***Noisy SMS Machine Translation in Low-Density Languages***](https://statmt.org/wmt11/pdf/WMT40.pdf) <br>Vladimir Eidelman, Kristy Hollingshead and Philip Resnik |
+| | [***Stochastic Parse Tree Selection for an Existing RBMT System***](https://statmt.org/wmt11/pdf/WMT41.pdf) <br>Christian Federmann and Sabine Hunsicker |
+| | [***Joint WMT Submission of the QUAERO Project***](https://statmt.org/wmt11/pdf/WMT42.pdf) <br>Markus Freitag, Gregor Leusch, Joern Wuebker, Stephan Peitz, Hermann Ney, Teresa Herrmann, Jan Niehues, Alex Waibel, Alexandre Allauzen, Gilles Adda, Josep Maria Crego, Bianka Buschbeck, Tonio Wandmacher and Jean Senellart |
+| | [***CMU Syntax-Based Machine Translation at WMT 2011***](https://statmt.org/wmt11/pdf/WMT43.pdf) <br>Greg Hanneman and Alon Lavie |
+| | [***The Uppsala-FBK systems at WMT 2011***](https://statmt.org/wmt11/pdf/WMT44.pdf) <br>Christian Hardmeier, Jörg Tiedemann, Markus Saers, Marcello Federico and Mathur Prashant |
+| | [***The Karlsruhe Institute of Technology Translation Systems for the WMT 2011***](https://statmt.org/wmt11/pdf/WMT45.pdf) <br>Teresa Herrmann, Mohammed Mediani, Jan Niehues and Alex Waibel |
+| | [***CMU Haitian Creole-English Translation System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT46.pdf) <br>Sanjika Hewavitharana, Nguyen Bach, Qin Gao, Vamshi Ambati and Stephan Vogel |
+| | [***Experiments with word alignment, normalization and clause reordering for SMT between English and German***](https://statmt.org/wmt11/pdf/WMT47.pdf) <br>Maria Holmqvist, Sara Stymne and Lars Ahrenberg |
+| | [***The Value of Monolingual Crowdsourcing in a Real-World Translation Scenario: Simulation using Haitian Creole Emergency SMS Messages***](https://statmt.org/wmt11/pdf/WMT48.pdf) <br>Chang Hu, Philip Resnik, Yakov Kronrod, Vladimir Eidelman, Olivia Buzek and Benjamin B. Bederson |
+| | [***The RWTH Aachen Machine Translation System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT49.pdf) <br>Matthias Huck, Joern Wuebker, Christoph Schmidt, Markus Freitag, Stephan Peitz, Daniel Stein, Arnaud Dagnelies, Saab Mansour, Gregor Leusch and Hermann Ney |
+| | [***ILLC-UvA translation system for EMNLP-WMT 2011***](https://statmt.org/wmt11/pdf/WMT50.pdf) <br>Maxim Khalilov and Khalil Sima’an |
+| | [***UPM system for the translation task***](https://statmt.org/wmt11/pdf/WMT51.pdf) <br>Verónica López-Ludeña and Rubén San-Segundo |
+| | [***Two-step translation with grammatical post-processing***](https://statmt.org/wmt11/pdf/WMT52.pdf) <br>David Mareček, Rudolf Rosa, Petra Galuščáková and Ondrej Bojar |
+| | [***Influence of Parser Choice on Dependency-Based MT***](https://statmt.org/wmt11/pdf/WMT53.pdf) <br>Martin Popel, David Mareček, Nathan Green and Zdenek Zabokrtsky |
+| | [***The LIGA (LIG/LIA) Machine Translation System for WMT 2011***](https://statmt.org/wmt11/pdf/WMT54.pdf) <br>Marion Potet, Raphaël Rubino, Benjamin Lecouteux, Stéphane Huet, Laurent Besacier, Hervé Blanchon and Fabrice Lefèvre |
+| | [***Factored Translation with Unsupervised Word Clusters***](https://statmt.org/wmt11/pdf/WMT55.pdf) <br>Christian Rishj and Anders Sgaard |
+| | [***The BM-I2R Haitian-Créole-to-English translation system description for the WMT 2011 evaluation campaign***](https://statmt.org/wmt11/pdf/WMT56.pdf) <br>Marta R. Costa-jussà and Rafael E. Banchs |
+| | [***The Universitat d'Alacant hybrid machine translation system for WMT 2011***](https://statmt.org/wmt11/pdf/WMT57.pdf) <br>Víctor M. Sánchez-Cartagena, Felipe Sánchez-Martínez and Juan Antonio Pérez-Ortiz |
+| | [***LIUM’s SMT Machine Translation Systems for WMT 2011***](https://statmt.org/wmt11/pdf/WMT58.pdf) <br>Holger Schwenk, Patrik Lambert, Loïc Barrault, Christophe Servan, Sadaf Abdul-Rauf, Haithem Afli and Kashif Shah |
+| | [***Spell Checking Techniques for Replacement of Unknown Words and Data Cleaning for Haitian Creole SMS Translation***](https://statmt.org/wmt11/pdf/WMT59.pdf) <br>Sara Stymne |
+| | [***Joshua 3.0: Syntax-based Machine Translation with the Thrax Grammar Extractor***](https://statmt.org/wmt11/pdf/WMT60.pdf) <br>Jonathan Weese, Juri Ganitkevitch, Chris Callison-Burch, Matt Post and Adam Lopez |
+| | [***DFKI Hybrid Machine Translation System for WMT 2011 - On the Integration of SMT and RBMT***](https://statmt.org/wmt11/pdf/WMT61.pdf) <br>Jia Xu, Hans Uszkoreit, Casey Kennington, David Vilar and Xiaojun Zhang |
+| | [***CEU-UPV English-Spanish system for WMT11***](https://statmt.org/wmt11/pdf/WMT62.pdf) <br>Francisco Zamora-Martinez and Maria Jose Castro-Bleda |
+| | [***Hierarchical Phrase-Based MT at the Charles University for the WMT 2011 Shared Task***](https://statmt.org/wmt11/pdf/WMT63.pdf) <br>Daniel Zeman |
+| 12:40 – 14:00 |	🍴 |
+| 14:00 – 15:40 |	**Invited Talk** <br>[***Crisis MT: Developing A Cookbook for MT in Crisis Situations***](https://statmt.org/wmt11/pdf/WMT64.pdf) <br>William Lewis, Robert Munro and Stephan Vogel |
+| 15:40 – 16:10 | ☕️ |
+| 16:10 – 16:35 | **Session 7: Translation Models** <br>(Chair: Chris Dyer) <br>[***Generative Models of Monolingual and Bilingual Gappy Patterns***](https://statmt.org/wmt11/pdf/WMT65.pdf) <br>Kevin Gimpel and Noah A. Smith |
+| 16:35 – 17:00 | [***Extraction Programs: A Unified Approach to Translation Rule Extraction***](https://statmt.org/wmt11/pdf/WMT66.pdf) <br>Mark Hopkins, Greg Langmead and Tai Vo |
+| 17:00 – 17:25 | [***Bayesian Extraction of Minimal SCFG Rules for Hierarchical Phrase-based Translation***](https://statmt.org/wmt11/pdf/WMT67.pdf) <br>Baskaran Sankaran, Gholamreza Haffari and Anoop Sarkar |
+| 17:25 – 17:50 | [***From n-gram-based to CRF-based Translation Models***](https://statmt.org/wmt11/pdf/WMT68.pdf) <br>Thomas Lavergne, Alexandre Allauzen, Josep Maria Crego and François Yvon |
+
+## Results
+
+Full results of the shared tasks: [*Findings of the 2011 Workshop on Statistical Machine Translation*](https://statmt.org/wmt11/pdf/WMT03.pdf)
+
+### News translation
+
+The results are determined through human evaluation featuring [relative ranking](wmt.md#relative-ranking). The winner systems are listed according to their ≥ others score. It shows how frequently the winners were judged to be better than or equal to any other system.
+
+#### → English
+
+| Language pair | System | ≥ others |
+| --- | --- | --- |
+| Czech → <br> | `UEDIN` <br>`ONLINE-B`  | 0.69 <br>0.68 |
+| Spanish → <br> <br> <br> <br> | `ONLINE-B` <br>`ONLINE-A` <br>`KOC` <br>`SYSTRAN` <br>`ALACANT` | 0.72 <br>0.72 <br>0.67 <br>0.66 <br>0.66 |
+| French → <br> <br> <br> <br> <br> | `ONLINE-A` <br>`LIMSI` <br>`ONLINE-B` <br>`KIT` <br>`CMU-DENKOWSKI` <br>`RBMT-1` | 0.66 <br>0.66 <br>0.66 <br>0.64 <br>0.62 <br>0.58 |
+| German → <br> <br> <br> | `ONLINE-B` <br>`CMU-DYER` <br>`ONLINE-A` <br>`RWTH-WUEBKER` | 0.72 <br>0.66 <br>0.66 <br>0.59 |
+
+#### English →
+
+| Language pair | System | ≥ others |
+| --- | --- | --- |
+| → Czech <br> <br> <br> | `ONLINE-B` <br>`CU-MARECEK` <br>`UEDIN` <br>`CU-POPEL` | 0.65 <br>0.63 <br>0.59 <br>0.58 |
+| → Spanish <br> <br> <br> <br> <br> <br> | `ONLINE-B` <br>`ONLINE-A` <br>`RBMT-3` <br>`PROMT` <br>`CEU-UPV` <br>`UEDIN` <br>`UPPSALA` | 0.74 <br>0.72 <br>0.71 <br>0.70 <br>0.65 <br>0.64 <br>0.61 |
+| → French <br> <br> | `LIMSI` <br>`ONLINE-B` <br>`KIT` | 0.73 <br>0.70 <br>0.69 |
+| → German <br> <br> <br> <br> <br> <br> <br> <br> <br> | `RBMT-3` <br>`ONLINE-B` <br>`RBMT-1` <br>`DFKI-FEDERMANN` <br>`RBMT-4` <br>`RBMT-2` <br>`ONLINE-A` <br>`LIMSI` <br>`KIT` <br>`COPENHAGEN` | 0.73 <br>0.73 <br>0.70 <br>0.68 <br>0.66 <br>0.66 <br>0.65 <br>0.65 <br>0.64 <br>0.56 |
+


### PR DESCRIPTION
# Description

Updated the `WMT11` article to add details about the event, including the schedule and results. The results include more than one winning system per language pair, as stated in the event findings. It's explained by a large number of participants and a low number of judgments per system pair, making it difficult to achieve statistical significance. I didn't separate the constrained and unconstrained wins in the `Results` section as done for the 2015-2021 year results but would like to hear your thoughts about that as well, dear @cefoo. 

## Type of PR

- Edits _[WMT11]_


### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
