### PR TITLE
Create wmt07.md

### DIFF
--- a/events/events.md
+++ b/events/events.md
@@ -226,7 +226,7 @@ featured: true
 | ---- | ---- | ---- |
 | 8 - 12 August | AMTA 2006 - “Visions for the future of machine translation” | Cambridge, Massachusetts |
 | 19 - 20 June | EAMT 2006 | Oslo, Norway |
-| 8 - 9 June | **WMT06** | New York City, New York |
+| 8 - 9 June | [**WMT06**](wmt06.md) | New York City, New York |
 
 ## 2005
 

--- a/events/wmt.md
+++ b/events/wmt.md
@@ -129,15 +129,18 @@ Some people have been organisers over many years:
 
 ### Average score and average z-score
 
-For the **average score**, human assessment scores for translations are standardised according to each human assessor's overall mean and standard deviation. Then a system-level score is computed.
+For the **average score**, human assessment scores for translations are standardised according to each human assessor's overall mean and standard deviation.
+Then a system-level score is computed.
 
-**Average z-score** is a normalised version. It shows the distance between the average score for a system and the mean average score across all systems.
+**Average z-score** is a normalised version.
+It shows the distance between the average score for a system and the mean average score across all systems.
 
 Average score and average z-score are the main metrics used in the results for the translation shared task since WMT17.
 
 ### TrueSkill
 
-**TrueSkill** is a gaming rating system. Microsoft Research originally developed it for the Xbox Live gaming community. 
+**TrueSkill** is a gaming rating system.
+Microsoft Research originally developed it for the Xbox Live gaming community. 
 For WMT, TrueSkill was adapted to machine translation evaluation.
 
 For WMT14, WMT15 and WMT16, TrueSkill was used as the human evaluation ranking for all translation shared tasks.

--- a/events/wmt.md
+++ b/events/wmt.md
@@ -39,7 +39,7 @@ Universities, research laboratories and big technology companies consistently pa
 | [WMT09](wmt09.md) | Workshop on Statistical Machine Translation | EACL 2009 |
 | [WMT08](wmt08.md) | Workshop on Statistical Machine Translation | ACL 2008 |
 | [WMT07](wmt07.md) | Workshop on Statistical Machine Translation | ACL 2007 |
-| WMT06 | Workshop on Statistical Machine Translation | NAACL 2006 |
+| [WMT06](wmt06.md) | Workshop on Statistical Machine Translation | NAACL 2006 |
 
 ## Shared tasks
 

--- a/events/wmt.md
+++ b/events/wmt.md
@@ -144,7 +144,8 @@ For WMT14, WMT15 and WMT16, TrueSkill was used as the human evaluation ranking f
 
 ### Adequacy and fluency judgement
 
-In **adequacy and fluency judgement**, for each input, humans rank the output from each system for both adequacy and fluency, on five-point scales.
+In **adequacy and fluency judgement**, for each input, humans rank the output from each system for both adequacy and fluency.
+Adequacy and fluency scores indicate the meaning adequacy and translation fluency of the system outputs on a five-point scale.
 
 Adequacy and fluency judgement was the official ranking for the translation shared task from WMT06 to WMT07.
 
@@ -160,12 +161,14 @@ Relative ranking was the official ranking for the translation shared task from W
 ### Constituent ranking
 
 In **constituent ranking**, for each input, humans rank the outputs of an automatically selected syntactic constituent instead of the complete sentences.
+The constituent score measures how often a system was judged to be better than any other system.
 
 Constituent ranking was the official ranking for the translation shared task from WMT07 to WMT08.
 
 ### Yes or no constituent judgement
 
 In **yes or no constituent judgement**, for each input, humans rank the acceptability of the outputs of an automatically selected syntactic constituent.
+The acceptability score measures the per cent of a system translation that was judged to be acceptable.
 
 Yes or no constituent judgement was added as an official ranking for WMT08.
 

--- a/events/wmt07.md
+++ b/events/wmt07.md
@@ -93,6 +93,8 @@ Full results of the shared task: [*(Meta-) Evaluation of Machine Translation*](h
 
 The results were determined with a [relative ranking](wmt.md#relative-ranking), the `> others` (“greater than others”) score, an [adequacy and fluency judgement](wmt.md#adequacy-and-fluency judgement), and a [constituent ranking](wmt.md#constituent-ranking).
 
+The automatic evaluation results were excluded from the article as the findings conclude the human judgments to be authoritative.
+
 #### → English
 
 | Language pair | System | `> others` | Adequacy | Fluency | Constituent |

--- a/events/wmt07.md
+++ b/events/wmt07.md
@@ -1,0 +1,124 @@
+---
+parent: Events
+title: WMT07
+description: Workshop on Machine Translation
+location: Prague, Czech Republic
+name: WMT07
+startDate: 2007-06-23
+
+seo:
+  type: Event
+  name: WMT07
+  description: Workshop on Machine Translation
+  startDate: 2007-06-23
+  endDate: 2007-06-23
+  eventAttendanceMode: OfflineEventAttendanceMode
+  eventStatus: EventScheduled
+
+  location:
+    type: PostalAddress
+    addressCountry: Prague
+    addressLocality: Czech Republic
+
+  organizer:
+    type: Person
+    url: https://www.statmt.org/wmt07/
+---
+
+The **Second Workshop on Machine Translation** (**WMT07**) took place on 23 June, 2007, in Prague, Czech Republic.
+
+[statmt.org/wmt07/program.html](https://statmt.org/wmt07/program.html)
+
+{% include collapsible_toc.html %}
+
+## Tasks
+
+- [Translation](https://www.statmt.org/wmt07/shared-task.html)
+
+## Schedule
+
+|     |     |
+| --- | --- |
+| 08:30 – 08:35 | **Opening Remarks** |
+| 08:35 – 08:55	| **Full Paper Session 1** <br>[***Using Dependency Order Templates to Improve Generality in Translation***](https://www.statmt.org/wmt07/pdf/WMT01.pdf) <br>Arul Menezes, Chris Quirk |
+| 08:55 – 09:15	| [***CCG Supertags in Factored Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT02.pdf) <br>Alexandra Birch, Miles Osborne, Philipp Koehn |
+| 09:15 – 09:35	| [***Integration of an Arabic Transliteration Module into a Statistical Machine Translation System***](https://www.statmt.org/wmt07/pdf/WMT03.pdf) <br>Mehdi M. Kashani, Eric Joanis, Roland Kuhn, George Foster, Fred Popowich |
+| 09:35 – 09:55	| [***Exploring Different Representational Units in English-to-Turkish Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT04.pdf) <br>Kemal Oflazer, Ilknur Durgar El-Kahlout |
+| 09:55 – 10:15	| [***Can We Translate Letters?***](https://www.statmt.org/wmt07/pdf/WMT05.pdf) <br>David Vilar, Jan-Thorsten Peter, Hermann Ney |
+| 10:15 – 10:45	| **Poster Session for Full Papers** <br>Boaster Session |
+| 10:45 – 11:45	| **Full Paper Poster Session** <br>☕️ |
+| | [***Context-aware Discriminative Phrase Selection for Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT19.pdf) <br>Jesús Giménez, Lluís Màrquez |
+| | [***A Dependency Treelet String Correspondence Model for Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT06.pdf) <br>Deyi Xiong, Qun Liu, Shouxun Lin |
+| | [***Word Error Rates: Decomposition over POS classes and Applications for Error Analysis***](https://www.statmt.org/wmt07/pdf/WMT07.pdf) <br>Maja Popovic, Hermann Ney |
+| | [***Speech-Input Multi-Target Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT08.pdf) <br>Alicia Pérez, M. Teresa González, M. Inés Torres, Francisco Casacuberta |
+| | [***Meta-Structure Transformation Model for Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT09.pdf) <br>Jiadong Sun, Tiejun Zhao,  Huashen Liang |
+| | [***Training Non-Parametric Features for Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT10.pdf) <br>Patrick Nguyen, Milind Mahajan, Xiaodong He |
+| | [***Using Word-Dependent Transition Models in HMM-Based Word Alignment for Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT11.pdf) <br>Xiaodong He |
+| | [***Efficient Handling of N-gram Language Models for Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT12.pdf) <br>Marcello Federico, Mauro Cettolo |
+| | [***Human Evaluation of Machine Translation Through Binary System Comparisons***](https://www.statmt.org/wmt07/pdf/WMT13.pdf) <br>David Vilar, Gregor Leusch, Hermann Ney, Rafael E. Banchs |
+| | [***Labelled Dependencies in Machine Translation Evaluation***](https://www.statmt.org/wmt07/pdf/WMT14.pdf) <br>Karolina Owczarzak, Josef van Genabith, Andy Way |
+| 11:45 – 12:30	| **Invited Talk** <br>Jean Senellart, Systran |
+| 12:30 - 14:00 |	🍴 |
+| 14:00 – 14:20 | **Full Paper Session 2**	<br>[***An Iteratively-Trained Segmentation-Free Phrase Translation Model for Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT15.pdf) <br>Robert Moore, Chris Quirk |
+| 14:20 – 14:40	| [***Using Paraphrases for Parameter Tuning in Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT16.pdf) <br>Nitin Madnani, Necip Fazil Ayan, Philip Resnik, Bonnie Dorr |
+| 14:40 – 15:00	| [***Mixture-Model Adaptation for SMT***](https://www.statmt.org/wmt07/pdf/WMT17.pdf) <br>George Foster, Roland Kuhn |
+| 15:00 – 15:15	| **Shared Task** <br>[***(Meta-) Evaluation of Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT18.pdf) <br>Chris Callison-Burch, Cameron Fordyce, Philipp Koehn, Christof Monz, Josh Schroeder |
+| 15:15 – 15:45	| **Boaster Session for Shared Task Posters** |
+| 15:45 – 16:45	| **Shared Task Poster Session** <br>☕️ |
+| | [***Ngram-Based Statistical Machine Translation Enhanced with Multiple Weighted Reordering Hypotheses***](https://www.statmt.org/wmt07/pdf/WMT20.pdf) <br>Marta R. Costa-jussià, Josep M. Crego, Patrik Lambert, Maxim Khalilov, José A. R. Fonollosa, José B. Mariño, Rafael E. Banchs |
+| | [***Analysis of Statistical and Morphological Classes to Generate Weigthed Reordering Hypotheses on a Statistical Machine Translation System***](https://www.statmt.org/wmt07/pdf/WMT21.pdf) <br>Marta R. Costa-jussià, José A. R. Fonollosa |
+| | [***Domain Adaptation in Statistical Machine Translation with Mixture Modelling***](https://www.statmt.org/wmt07/pdf/WMT22.pdf) <br>Jorge Civera, Alfons Juan |
+| | [***Getting to Know Moses: Initial Experiments on German-English Factored Translation***](https://www.statmt.org/wmt07/pdf/WMT23.pdf) <br>Maria Holmqvist, Sara Stymne, Lars Ahrenberg |
+| | [***NRC’s PORTAGE System for WMT 2007***](https://www.statmt.org/wmt07/pdf/WMT24.pdf) <br>Nicola Ueffing, Michel Simard, Samuel Larkin, Howard Johnson |
+| | [***Building a Statistical Machine Translation System for French Using the Europarl Corpus***](https://www.statmt.org/wmt07/pdf/WMT25.pdf) <br>Holger Schwenk |
+| | [***Multi-Engine Machine Translation with an Open-Source SMT Decoder***](https://www.statmt.org/wmt07/pdf/WMT26.pdf) <br>Yu Chen, Andreas Eisele, Christian Federmann, Eva Hasler, Michael Jellinghaus, Silke Theison |
+| | [***The ISL Phrase-Based MT System for the 2007 ACL Workshop on Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT27.pdf) <br>Matthias Paulik, Kay Rottmann, Jan Niehues, Silja Hildebrand, Stephan Vogel |
+| | [***Rule-Based Translation with Statistical Phrase-Based Post-Editing***](https://www.statmt.org/wmt07/pdf/WMT28.pdf) <br>Michel Simard, Nicola Ueffing, Pierre Isabelle, Roland Kuhn |
+| | [***The "Noisier Channel": Translation from Morphologically Complex Languages***](https://www.statmt.org/wmt07/pdf/WMT29.pdf) <br>Christopher J. Dyer |
+| | [***UCB System Description for the WMT 2007 Shared Task***](https://www.statmt.org/wmt07/pdf/WMT30.pdf) <br>Preslav Nakov, Marti Hearst |
+| | [***The Syntax Augmented MT (SAMT) System at the Shared Task for the 2007 ACL Workshop on Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT31.pdf) <br>Andreas Zollmann, Ashish Venugopal, Matthias Paulik, Stephan Vogel |
+| | [***Statistical Post-Editing on SYSTRAN’s Rule-Based Translation System***](https://www.statmt.org/wmt07/pdf/WMT32.pdf) <br>Loïc Dugast, Jean Senellart, Philipp Koehn |
+| | [***Experiments in Domain Adaptation for Statistical Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT33.pdf) <br>Philipp Koehn, Josh Schroeder |
+| | [***METEOR: An Automatic Metric for MT Evaluation with High Levels of Correlation with Human Judgments***](https://www.statmt.org/wmt07/pdf/WMT34.pdf) <br>Alon Lavie, Abhaya Agarwal |
+| 16:45 – 17:05 | **Full Paper Session 4** <br>[***English-to-Czech Factored Machine Translation***](https://www.statmt.org/wmt07/pdf/WMT35.pdf) <br>Ondrej Bojar |
+| 17:05 – 17:25	| [***Sentence Level Machine Translation Evaluation as a Ranking***](https://www.statmt.org/wmt07/pdf/WMT36.pdf) <br>Yang Ye, Ming Zhou, Chin-Yew Lin |
+| 17:25 – 17:45	| [***Localization of Difficult-to-Translate Phrases***](https://www.statmt.org/wmt07/pdf/WMT37.pdf) <br>Behrang Mohit, Rebecca Hwa |
+| 17:45 – 18:05	| [***Linguistic Features for Automatic Evaluation of Heterogenous MT Systems***](https://www.statmt.org/wmt07/pdf/WMT38.pdf) <br>Jesús Giménez, Lluís Màrquez |
+
+## Results
+
+Full results of the shared task: [*(Meta-) Evaluation of Machine Translation*](https://www.statmt.org/wmt07/pdf/WMT18.pdf)
+
+### Translation
+
+The results were determined with a [relative ranking](wmt.md#relative-ranking), the `> others` (“greater than others”) score, [adequacy and fluency judgement](wmt.md#adequacy-and-fluency judgement), and [constituent ranking](wmt.md#constituent-ranking).
+
+The `> others` score measures how often a system was judged to be better than any other system.
+
+Adequacy and fluency scores indicate the meaning adequacy and translation fluency of the system outputs on a five-point scale.
+
+The constituent score measures how often a system was judged to be better than any other system in the constituent-based evaluation.
+
+#### → English
+
+| Language pair | System | `> others` | Adequacy | Fluency | Constituent |
+| --- | --- | --- | --- | --- | --- |
+| Czech  News → | `UMD` | 0.627 | 0.550 | 0.592 | - |
+| French Europarl → | `LIMSI` <br>`UEDIN` | - <br>0.514 | 0.634 <br>- | - <br>0.635 | 0.290 <br>- |
+| French  News → | `LIMSI` <br>`UPC` | 0.494 <br>- | - <br>0.576 | 0.596 <br>- | 0.312 <br>- |
+| German Europarl → | `SYSTRAN` | 0.530 | 0.562 | 0.594 | 0.302 |
+| German  News → | `SYSTRAN` | 0.563 | 0.552 | 0.560 | 0.344 |
+| Spanish Europarl → | `UEDIN` <br>`UPC` | - <br>0.500 | 0.593 <br>- | 0.610 <br>- | - <br>0.188 |
+| Spanish  News → | `UPC` | 0.537 | 0.566 | 0.543 | 0.312 |
+
+#### English →
+
+| Language pair | System | `> others` | Adequacy | Fluency | Constituent |
+| --- | --- | --- | --- | --- | --- |
+| → Czech  News | `PCT` <br>`CU`| 0.499 <br>- | 0.542 <br>- | 0.541 <br>- | - <br>0.440 |
+| → French Europarl | `SYSTRAN-NRC` <br>`LIMSI` <br>`UEDIN` | 0.512 <br>- <br>- | - <br>0.635 <br>- | - <br>0.627 <br>- | - <br>- <br>0.273 |
+| → French  News | `SYSTRAN` <br>`SYSTRAN-NRC` | 0.634 <br>- | - <br>0.557 | - <br>0.572 | 0.440 <br>- |
+| → German Europarl | `SYSTRAN` <br>`UEDIN` | 0.511 <br>- | - <br>0.569 | - <br>0.576 | - <br>0.350 |
+| → German  News | `SYSTRAN` | 0.582 | 0.542 | 0.556 | 0.351 |
+| → Spanish Europarl | `UEDIN` <br>`UPV` | 0.468 <br>- | 0.586 <br>- | 0.638 <br>- | - <br>0.246 |
+| → Spanish  News | `SYSTRAN` <br>`UPC` | 0.481 <br>- | - <br>0.510 | 0.507 <br>- | 0.352 <br>- |

--- a/events/wmt07.md
+++ b/events/wmt07.md
@@ -91,7 +91,7 @@ Full results of the shared task: [*(Meta-) Evaluation of Machine Translation*](h
 
 ### Translation
 
-The results were determined with a [relative ranking](wmt.md#relative-ranking), the `> others` (“greater than others”) score, [adequacy and fluency judgement](wmt.md#adequacy-and-fluency judgement), and [constituent ranking](wmt.md#constituent-ranking).
+The results were determined with a [relative ranking](wmt.md#relative-ranking), the `> others` (“greater than others”) score, an [adequacy and fluency judgement](wmt.md#adequacy-and-fluency judgement), and a [constituent ranking](wmt.md#constituent-ranking).
 
 The `> others` score measures how often a system was judged to be better than any other system.
 

--- a/events/wmt07.md
+++ b/events/wmt07.md
@@ -93,12 +93,6 @@ Full results of the shared task: [*(Meta-) Evaluation of Machine Translation*](h
 
 The results were determined with a [relative ranking](wmt.md#relative-ranking), the `> others` (“greater than others”) score, an [adequacy and fluency judgement](wmt.md#adequacy-and-fluency judgement), and a [constituent ranking](wmt.md#constituent-ranking).
 
-The `> others` score measures how often a system was judged to be better than any other system.
-
-Adequacy and fluency scores indicate the meaning adequacy and translation fluency of the system outputs on a five-point scale.
-
-The constituent score measures how often a system was judged to be better than any other system in the constituent-based evaluation.
-
 #### → English
 
 | Language pair | System | `> others` | Adequacy | Fluency | Constituent |


### PR DESCRIPTION
# Description

Created the WMT07 article to add details about the event, including the schedule and results. The automatic evaluation results were excluded from the article as the findings conclude the human judgments to be authoritative. Let me know if you think we should add automatic evaluation results as well, @cefoo!

## Type of PR

- Creates the article _[WMT07]_

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
