### PR TITLE
Pin pmarsceill/just-the-docs to v0.3.3 to avoid performance degradation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -133,7 +133,7 @@ defaults:
 
 # Just the Docs
 
-remote_theme: pmarsceill/just-the-docs
+remote_theme: pmarsceill/just-the-docs@v0.3.3
 
 logo: favicon.ico
 color_scheme: swissred


### PR DESCRIPTION
# Description

pmarsceill/just-the-docs recently published a Release Candidate for [v0.4.0.rc2](https://github.com/just-the-docs/just-the-docs/releases/tag/v0.4.0.rc2). It affected the build time for this project, which went from around ten minutes to over an hour.

<img width="960" alt="Screen Shot 2022-09-23 at 18 33 39" src="https://user-images.githubusercontent.com/895/192060049-36259cd3-e938-4a1c-80c6-f4244f8d9d4e.png">

This PR pins the remote theme to v0.3.3, which is the version that was in use since the beginning.

## Type of PR

- Other (build time improvement)

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [ ] I have followed the [style guide](http://machinetranslate.org/style). **N/A**
