### PR TITLE
Add missing languages

### DIFF
--- a/_data/language-families.yml
+++ b/_data/language-families.yml
@@ -1,6 +1,7 @@
 ---
 aav: Austroasiatic
 afa: Afro-Asiatic
+aym: Aymaran
 bat: Baltic
 bnt: Bantu
 ccs: Kartvelian
@@ -12,6 +13,7 @@ cpp: Portuguese-based creoles
 crp: Creoles
 cus: Cushitic
 dra: Dravidian
+esx: Eskimo–Aleut
 fiu: Finno-Ugric
 gem: Germanic
 grk: Hellenic
@@ -20,10 +22,13 @@ iir: Indo-Iranian
 ine: Indo-European
 inc: Indo-Aryan
 ira: Iranic
+iro: Iroquoian
 jpx: Japonic
 kor: Koreanic # There is no standard code for this.
 map: Austronesian
+myn: Mayan
 nic: Niger-Congo
+omq: Oto-Manguean
 roa: Romance
 sem: Semitic
 sit: Sino-Tibetan

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -172,7 +172,7 @@
   territories: [ fr ]
 
 -
-  codes: [ bs, bos ]
+  codes: [ bs, bos, cnr ]
   names: [ Bosnian ]
   variant_names: [ Serbo-Croatian ]
   family: [ sla, ine ]

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -21,6 +21,16 @@
   territories: [ et ]
 
 -
+  codes: [ an, arg ]
+  names: [ Aragonese ]
+  family: [ roa, ine ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ fusional, inflected ]
+  territories: [ es ]
+
+-
   codes: [ ar, ara ]
   names: [ Arabic ]
   family: [ sem, afa ]
@@ -29,6 +39,36 @@
     word_order: [ VSO ]
     morphosyntax: [ fusional, synthetic ]
   territories: [ ae, bh, dj, dz, eg, er, iq, jo, kw, lb, ly, ma, mr, om, ps, qa, sa, sd, so, sy, tn, ye ]
+
+-
+  codes: [ as, asm ]
+  names: [ Assamese, Asamiya ]
+  family: [ inc, ine ]
+  scripts: [ Beng ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ inflected ]
+  territories: [ in ]
+
+-
+  codes: [ ast ]
+  names: [ Asturian, Bable ]
+  family: [ roa ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ inflected ]
+  territories: [ es ]
+
+-
+  codes: [ ay, aym, ayc, ayr ]
+  names: [ Aymara ]
+  family: [ aym ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ agglutinative ]
+  territories: [ bo, pe ]
 
 -
   codes: [ az, aze, azj, azb ]
@@ -41,6 +81,16 @@
   territories: [ az, ir, iq ]
 
 -
+  codes: [ ba, bak ]
+  names: [ Bashkir ]
+  family: [ trk ]
+  scripts: [ Cyrl ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ agglutinative ]
+  territories: [ ru ]
+
+-
   codes: [ be, bel ]
   names: [ Belarusian ]
   family: [ sla, ine ]
@@ -49,6 +99,26 @@
     word_order: [ SVO ]
     morphosyntax: [ inflected ]
   territories: [ by ]
+
+-
+  codes: [ bem ]
+  names: [ Bemba, ChiBemba, Cibemba, Ichibemba, Icibemba, Chiwemba ]
+  family: [ bnt ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ agglutinative ]
+  territories: [ zm, cd, tz ]
+
+-
+  codes: [ ber ]
+  names: [ Berber ]
+  family: [ afa ]
+  scripts: [ Tfng, Arab, Latn ]
+  typology:
+    word_order: [ VSO ]
+    morphosyntax: [ fusional ]
+  territories: [ ma, dz, ly, ml, ne ]
 
 -
   codes: [ bg, bul ]
@@ -61,6 +131,16 @@
   territories: [ bg ]
 
 -
+  codes: [ bi, bis ]
+  names: [ Bislama, Bichelama ]
+  family: [ cpe ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ analytic ]
+  territories: [ vu ]
+
+-
   codes: [ bn, ben ]
   names: [ Bengali, Bangla ]
   family: [ inc, iir, ine ]
@@ -69,6 +149,27 @@
     word_order: [ SOV ]
     morphosyntax: [ inflected ]
   territories: [ bd, in ]
+
+-
+  codes: [ bo, bod, tib ]
+  names: [ Tibetan, Lhasa Tibetan, Standard Tibetan ]
+  family: [ sit ]
+  scripts: [ Tibt ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ agglutinative ]
+  territories: [ cn, np, in ]
+
+-
+  codes: [ br, bre, xbm, obt ]
+  names: [ Breton ]
+  variant_names: [ Modern Breton, Middle Breton, Old Breton ]
+  family: [ cel, ine ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ VSO ]
+    morphosyntax: [ inflected ]
+  territories: [ fr ]
 
 -
   codes: [ bs, bos ]
@@ -111,6 +212,26 @@
   territories: [ fr ]
 
 -
+  codes: [ chr ]
+  names: [ Cherokee, Tsalagi ]
+  family: [ iro ]
+  scripts: [ Cher ]
+  typology:
+    word_order: [ SOV, OVS ]
+    morphosyntax: [ inflected ]
+  territories: [ us ]
+
+-
+  codes: [ crh ]
+  names: [ Crimean Tatar, Crimean ]
+  family: [ trk ]
+  scripts: [ Latn, Cyrl ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ agglutinative ]
+  territories: [ ro, ru, uk ]
+
+-
   codes: [ cs, ces, cze ]
   names: [ Czech ]
   family: [ sla, ine ]
@@ -149,6 +270,16 @@
     word_order: [ SVO, VSO ]
     morphosyntax: [ fusional ]
   territories: [ at, ch, de, li, lu ]
+
+-
+  codes: [ dv, div ]
+  names: [ Divehi, Dhivehi, Maldivian ]
+  family: [ inc, iir, ine ]
+  scripts: [ Latn, Thaa ]
+  typology:
+    word_order: [  ]
+    morphosyntax: [ inflected ]
+  territories: [ mv ]
 
 -
   codes: [ el, gre, ell ]
@@ -231,6 +362,26 @@
     word_order: [ SVO, SOV ]
     morphosyntax: [ agglutinative ]
   territories: [ fi ]
+
+-
+  codes: [ fj, fij ]
+  names: [ Fijian ]
+  family: [ map ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ VOS ]
+    morphosyntax: [ isolating ]
+  territories: [ fj ]
+
+-
+  codes: [ fo, fao ]
+  names: [ Faroese ]
+  family: [ gem ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ inflected ]
+  territories: [ fo ]
 
 -
   codes: [ fr, fra, fre ]
@@ -354,6 +505,16 @@
   territories: [ hr, ba, rs, at ]
 
 -
+  codes: [ hsb ]
+  names: [ Upper Sorbian, Wendish ]
+  family: [ sla, ine ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ inflected ]
+  territories: [ de ]
+
+-
   codes: [ ht, hat ]
   names: [ Haitian, Haitian Creole ]
   family: [ cpf ]
@@ -424,6 +585,16 @@
   territories: [ ch, it ]
 
 -
+  codes: [ iu, iku, ike, ikt ]
+  names: [ Inuktitut, Eastern Canadian Inuktitut ]
+  family: [ esx ]
+  scripts: [ Cans ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ agglutinative, polysynthetic ]
+  territories: [ ca ]
+
+-
   codes: [ ja, jpn ]
   names: [ Japanese ]
   family: [ jpx ]
@@ -452,6 +623,16 @@
     word_order: [ SVO ]
     morphosyntax: [ agglutinative, synthetic ]
   territories: [ ge ]
+
+-
+  codes: [ kab ]
+  names: [ Kabyle, Kabylian ]
+  family: [ afa ]
+  scripts: [ Arab, Latn ]
+  typology:
+    word_order: [ VSO ]
+    morphosyntax: [ inflected ]
+  territories: [ dz ]
 
 -
   codes: [ kk, kaz ]
@@ -574,6 +755,16 @@
   territories: [ lv ]
 
 -
+  codes: [ mah ]
+  names: [ Marshallese, Ebon ]
+  family: [ aav ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ fusional, synthetic ]
+  territories: [ mh ]
+
+-
   codes: [ mg, mlg, xmv, bhr, buc, msh, bmm, plt, skg, bzc, tdx, txy, tkg, xmw ]
   names: [ Malagasy ]
   variant_names: [ Antankarana, Bara, Bushi, Masikoro, Northern Betsimisaraka, Plateau Malagasy, Sakalava, Southern Betsimisaraka, Tandroy-Mafahaly, Tanosy, Tesaka, Tsimihety ]
@@ -583,6 +774,19 @@
     word_order: [ VOS ]
     morphosyntax: [ inflected ]
   territories: [ mg ]
+
+-
+  codes: [ mhr ]
+  names: [ Meadow Mari, Meadow-Eastern Mari, Eastern Mari ]
+  family: [ fiu ]
+  scripts: [ Cyrl ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ agglutinative ]
+  territories: [ ru ]
+# urls:
+#  https://mari-language.univie.ac.at/grammar/eg2022.pdf
+# https://en.wikipedia.org/wiki/Mari_language
 
 -
   codes: [ mi, mri, mao ]
@@ -633,6 +837,19 @@
     word_order: [ SOV ]
     morphosyntax: [ agglutinative, inflected, analytic ]
   territories: [ in ]
+
+-
+  codes: [ mrj ]
+  names: [ Hill Mari, Western Mari ]
+  family: [ fiu ]
+  scripts: [ Cyrl ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ agglutinative ]
+  territories: [ ru ]
+# urls:
+#  https://mari-language.univie.ac.at/grammar/eg2022.pdf
+# https://en.wikipedia.org/wiki/Mari_language
 
 -
   codes: [ ms, msa, may ]
@@ -705,6 +922,16 @@
   territories: [ mw, zw ]
 
 -
+  codes: [ oc, oci ]
+  names: [ Occitan ]
+  family: [ roa, ine ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [  ]
+    morphosyntax: [  ]
+  territories: [ es, fr, it, mc ]
+
+-
   codes: [ or, ori ]
   names: [ Oriya, Odia ]
   family: [ inc, iir, ine ]
@@ -715,6 +942,14 @@
   territories: [ id ]
 
 -
+  codes: [ otq ]
+  names: [ Northwestern Otomi ]
+  variant_names: [ Mezquital Otomi, Querétaro Otomi ]
+  family: [ omq ]
+  scripts: [ Latn ]
+  territories: [ mx ]
+
+-
   codes: [ pa, pan ]
   names: [ Punjabi, Panjabi ]
   family: [ inc, iir, ine ]
@@ -723,6 +958,16 @@
     word_order: [ SOV ]
     morphosyntax: [ fusional ]
   territories: [ pk, in ]
+
+-
+  codes: [ pap ]
+  names: [ Papiamento, Papiamentu ]
+  family: [ cpp ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax:
+  territories: [ aw, cw ]
 
 -
   codes: [ pl, pol ]
@@ -765,6 +1010,16 @@
   territories: [ md, ro ]
 
 -
+  codes: [ rm, roh ]
+  names: [ Romansh, Romansch, Rumantsch ]
+  family: [ roa, ine ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ synthetic ]
+  territories: [ ch ]
+
+-
   codes: [ ru, rus ]
   names: [ Russian ]
   family: [ sla, ine ]
@@ -785,6 +1040,16 @@
   territories: [ rw ]
 
 -
+  codes: [ sc, srd, sro, src ]
+  names: [ Sardinian ]
+  family: [ roa, ine ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ inflected ]
+  territories: [ it ]
+
+-
   codes: [ sd, snd ]
   names: [ Sindhi ]
   family: [ inc, iir, ine ]
@@ -793,6 +1058,16 @@
     word_order: [ SOV ]
     morphosyntax: [ inflected ]
   territories: [ in, pk ]
+
+-
+  codes: [ se, sme ]
+  names: [ Northern Sami, North Sámi, Northern Sámi ]
+  family: [ fiu ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ agglutinative, inflected, fusional ]
+  territories: [ 'no', fi, se ]
 
 -
   codes: [ si, sin ]
@@ -915,6 +1190,13 @@
   territories: [ cd, ke, tz, ug ]
 
 -
+  codes: [ szl ]
+  names: [ Silesian ]
+  variant_names: [ Upper Silesian ]
+  family: [ sla, ine ]
+  territories: [ pl, cz ]
+
+-
   codes: [ ta, tam ]
   names: [ Tamil ]
   family: [ dra ]
@@ -945,6 +1227,17 @@
   territories: [ tj, af ]
 
 -
+  codes: [ tet ]
+  names: [ Tetum, Tetun ]
+  variant_name: [ Tetun Dili, Tetun Terik ]
+  family: [ map ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ isolating ]
+  territories: [ tl ]
+
+-
   codes: [ th, tha ]
   names: [ Thai, Central Thai ]
   family: [ tai ]
@@ -963,7 +1256,7 @@
     word_order: [ SOV ]
     morphosyntax: [ fusional, synthetic ]
   territories: [ et, er ]
-  
+
 -
   codes: [ tk, tuk ]
   names: [ Turkmen ]
@@ -985,6 +1278,26 @@
   territories: [ ph ]
 
 -
+  codes: [ tlh ]
+  names: [ Klingon, Klingonese ]
+  family: [  ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ OVS ]
+    morphosyntax: [ agglutinative ]
+  territories: [ ]
+
+-
+  code: [ to, ton ]
+  names: [ Tonga, Tongan ]
+  family: [ map ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ VSO ]
+    morphosyntax: [ analytic ]
+  territories: [ to ]
+
+-
   codes: [ tr, tur ]
   names: [ Turkish ]
   family: [ trk ]
@@ -1003,6 +1316,26 @@
     word_order: [ SOV ]
     morphosyntax: [ agglutinative ]
   territories: [ ru, cn ]
+
+-
+  codes: [ ty, tah ]
+  names: [ Tahitian ]
+  family: [ map ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ VSO ]
+    morphosyntax: [ analytic ]
+  territories: [ pf ]
+
+-
+  codes: [ udm ]
+  names: [ Udmurt ]
+  family: [ fiu ]
+  scripts: [ Cyrl ]
+  typology:
+    word_order: [ SOV ]
+    morphosyntax: [ agglutinative ]
+  territories: [ ru ]
 
 -
   codes: [ ug, uig ]
@@ -1055,6 +1388,16 @@
   territories: [ vn ]
 
 -
+  codes: [ wol ]
+  names: [ Wolof ]
+  family: [ nic ]
+  scripts: [ Latn, Arab ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ inflected, agglutinative ]
+  territories: [ sn, mr, gm ]
+
+-
   codes: [ xh, xho ]
   names: [ Xhosa, isiXhosa ]
   family: [ bnt, nic ]
@@ -1083,6 +1426,24 @@
     word_order: [ SVO ]
     morphosyntax: [ isolating ]
   territories: [ ]
+
+-
+  codes: [ yua ]
+  names: [ Yucatec Maya ]
+  family: [ myn ]
+  scripts: [ Latn ]
+  typology:
+    word_order: [ VOS ]
+  territories: [ mx ]
+-
+  codes: [ yue ]
+  names: [ Cantonese, Yue, Yue Chinese ]
+  family: [ sit ]
+  scripts: [ Hans, Hant ]
+  typology:
+    word_order: [ SVO ]
+    morphosyntax: [ analytic, isolating ]
+  territories: [ hk, mo ]
 
 -
   codes: [ zh, lzh ]

--- a/_data/scripts.yml
+++ b/_data/scripts.yml
@@ -3,6 +3,7 @@ Arab: Arabic
 Armn: Armenian
 Beng: Bengali
 Cans: Canadian
+Cher: Cherokee
 Cyrl: Cyrillic
 Deva: Devanagari
 Elba: Elbasan
@@ -41,3 +42,4 @@ Taml: Tamil
 Telu: Telugu
 Tibt: Tibetan
 Thai: Thai
+Tfng: Tifinagh


### PR DESCRIPTION
# Add languages to languages.yml

Fixes #304

## Type of PR

- Edits `languages.yml`, `scripts.yml`, and `language-families.md`


### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).

### Comments:

- `oc` (Occitan) is missing `typology` information.
- `szl` (Silesian) is missing `script`and `typology` information.
- `cnr` (Montenegrin) is a variant of Serbo-Croatian, which we already have. I added `cnr` to the Serbo-Croatian language codes.
- `lzh` (Classical Chinese) is included in the `zh` language entry.

- Languages added and languages still missing are reported in this #304 issue [comment](https://github.com/machinetranslate/machinetranslate.org/issues/304#issuecomment-1293901831).