### PR TITLE
Add 2-letter codes for Wolof and Marshallese

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -754,7 +754,7 @@
   territories: [ lv ]
 
 -
-  codes: [ mah ]
+  codes: [ mh, mah ]
   names: [ Marshallese, Ebon ]
   family: [ aav ]
   scripts: [ Latn ]
@@ -1387,7 +1387,7 @@
   territories: [ vn ]
 
 -
-  codes: [ wol ]
+  codes: [ wo, wol ]
   names: [ Wolof ]
   family: [ nic ]
   scripts: [ Latn, Arab ]


### PR DESCRIPTION
Add 2-letter codes for Wolof and Marshallese.

# Description

These languages were shown as having 0 APIs, because the APIs that support them use the 2-letter code.

<img width="1260" alt="Screenshot 2022-11-26 at 21 30 07" src="https://user-images.githubusercontent.com/11457984/204101483-0ceb37b7-2e7d-4fc5-9b5b-6e1cd5799eff.png">

## Type of PR

- Data bug fix

### Checklist:

- [ x ] I have read the [contributing guidelines](contributing.md).
- [ x ] I have followed the [style guide](http://machinetranslate.org/style).
