### PR TITLE
Add arm:hy to API:language mapping

### DIFF
--- a/_data/api-language.yml
+++ b/_data/api-language.yml
@@ -16,6 +16,7 @@ microsoft:
   prs: fa-af # Macrolanguage, Microsoft for Dari
   fil: tl # Macrolanguage, Microsoft for Tagalog
   mww: hmn # Macrolanguage, Microsoft for Hmong
+  arm: hy
   aar: aa
   abk: ab
   afr: af


### PR DESCRIPTION
Baidu uses `arm`

Seems like the other 3-letter codes that some APIs use, like `woh`, `mah` etc are already in the mapping.

We just need to regenerate.

# Description

Fixes the fact that Armenian is missing from Baidu

## Type of PR

- Data bug fix

### Checklist:

- [ x ] I have read the [contributing guidelines](contributing.md).
- [ x ] I have followed the [style guide](http://machinetranslate.org/style).
