### PR TITLE
Create locale.md

### DIFF
--- a/applications/advanced-concepts/locale.md
+++ b/applications/advanced-concepts/locale.md
@@ -1,0 +1,33 @@
+---
+parent: Building and research
+title: Locale
+description: Specification of language variants
+---
+
+A **locale** is an identifier of a language and region plus an optional writing script.
+The locale is used in machine translation APIs to specify the language and variation of the language of both the source and target text.
+Locales are also used to select the desired language in mobile phones, on webpages to hints for web browsers and web crawlers, and in language identification.
+
+Example: `frCA` means french (fr) as spoken in Canada (CA)
+
+Language codes are typically specified in two or three characters according to ISO 639.
+Regions are typically specified in two characters according to ISO 3166.
+Scripts are sometimes specified according to ISO 15924, such as sr-Cyrl_RS for Serbian written in Cyrllic script in Serbia.
+
+## API Support
+
+These language variations are supported by many API vendors:
+
+- Chinese (zh): zh-cn, zh-tw
+- Portuguese (pr): pr-pr, pr-br
+- French (fr): fr-fr, fr-ca
+- Spanish (es): es-es, es-mx, es-419 (Latin America)
+- English (en): en-us, en-gb
+- Serbian (sr): sr-Cyrl-rs, sr-Latn-rs
+
+## Challenges
+
+- When a region code is not specified for a language with significant regional variation, the user may not know which regional variation will be used
+- Some commonly-written languages do not have language codes. For example, Hinglish is not acknowledged as a distinct language from Hindi and English and does not have a language code
+- A country code may be too specific at times, and region codes may not exist for all regions of interest
+- A region code may not be specific enough if there is significant variation within a country

--- a/applications/advanced-concepts/locale.md
+++ b/applications/advanced-concepts/locale.md
@@ -5,29 +5,30 @@ description: Specification of language variants
 ---
 
 A **locale** is an identifier of a language and region plus an optional writing script.
-The locale is used in machine translation APIs to specify the language and variation of the language of both the source and target text.
-Locales are also used to select the desired language in mobile phones, on webpages to hints for web browsers and web crawlers, and in language identification.
+The locale is used in [machine translation APIs](/apis/apis.md) to specify the language and variation of the language of both the source and target text.
+Locales are commonly used to set the default language on mobile phones and computers.
+Locales are also an important concept when [web crawling](/customisation/crawling.md) to build [training data](/customisation/crawling.md).
 
 Example: `frCA` means french (fr) as spoken in Canada (CA)
 
 Language codes are typically specified in two or three characters according to ISO 639.
 Regions are typically specified in two characters according to ISO 3166.
-Scripts are sometimes specified according to ISO 15924, such as sr-Cyrl_RS for Serbian written in Cyrllic script in Serbia.
+Scripts are sometimes specified according to ISO 15924, such as `sr-Cyrl_RS` for Serbian written in Cyrllic script in Serbia.
 
 ## API Support
 
 These language variations are supported by many API vendors:
 
-- Chinese (zh): zh-cn, zh-tw
-- Portuguese (pr): pr-pr, pr-br
-- French (fr): fr-fr, fr-ca
-- Spanish (es): es-es, es-mx, es-419 (Latin America)
-- English (en): en-us, en-gb
-- Serbian (sr): sr-Cyrl-rs, sr-Latn-rs
+- Chinese (`zh`): Chinese, Simplified (`zh-cn`, also `zh-Hans`), Chinese, Traditional (`zh-tw`, also `zh-Hant`)
+- Portuguese (`pr`): Portugal (`pr-pr`), Brazil (`pr-br`)
+- French (`fr`): France (`fr-fr`), Canada (`fr-ca`)
+- Spanish (`es`): Spain (`es-es`), Mexico (`es-mx`), Latin America (`es-419`)
+- English (`en`): United States (`en-us`), Great Britain (`en-gb`)
+- Serbian (`sr`): Serbia, Cyrillic script (`sr-Cyrl-rs`), Serbia, Latin script (`sr-Latn-rs`)
 
 ## Challenges
 
-- When a region code is not specified for a language with significant regional variation, the user may not know which regional variation will be used
-- Some commonly-written languages do not have language codes. For example, Hinglish is not acknowledged as a distinct language from Hindi and English and does not have a language code
-- A country code may be too specific at times, and region codes may not exist for all regions of interest
-- A region code may not be specific enough if there is significant variation within a country
+- When a region and script are not specified, the underlying MT model may be built for the most common language variant or it may be built on a mix of variants
+- Not all languages or variants have standardized locale codes
+- In some cases the locale codes have changed over time. For example, old systems may represent Cantonese as zhHK while newer systems use the newer language code yue
+

--- a/applications/advanced-concepts/locale.md
+++ b/applications/advanced-concepts/locale.md
@@ -30,5 +30,5 @@ These language variations are supported by many API vendors:
 
 - When a region and script are not specified, the underlying MT model may be built for the most common language variant or it may be built on a mix of variants
 - Not all languages or variants have standardized locale codes
-- In some cases the locale codes have changed over time. For example, old systems may represent Cantonese as zhHK while newer systems use the newer language code yue
+- In some cases the locale codes have changed over time. For example, old systems may represent Cantonese as `zhHK` while newer systems use the newer language code `yue`
 

--- a/applications/advanced-concepts/locale.md
+++ b/applications/advanced-concepts/locale.md
@@ -22,7 +22,7 @@ These language variations are supported by many API vendors:
 - Chinese (`zh`): Chinese, Simplified (`zh-cn`, also `zh-Hans`), Chinese, Traditional (`zh-tw`, also `zh-Hant`)
 - Portuguese (`pr`): Portugal (`pr-pr`), Brazil (`pr-br`)
 - French (`fr`): France (`fr-fr`), Canada (`fr-ca`)
-- Spanish (`es`): Spain (`es-es`), Mexico (`es-mx`), Latin America (`es-419`)
+- Spanish (`es`): Spain (`es-es`), Mexico (`es-mx`), Latin America and Caribbean region (`es-419`)
 - English (`en`): United States (`en-us`), Great Britain (`en-gb`)
 - Serbian (`sr`): Serbia, Cyrillic script (`sr-Cyrl-rs`), Serbia, Latin script (`sr-Latn-rs`)
 - Norwegian (`no`): Norwegian Bokmål (`nb`, `nob`), Norwegian Nynorsk (`nn`, `nno`)

--- a/applications/advanced-concepts/locale.md
+++ b/applications/advanced-concepts/locale.md
@@ -25,6 +25,7 @@ These language variations are supported by many API vendors:
 - Spanish (`es`): Spain (`es-es`), Mexico (`es-mx`), Latin America (`es-419`)
 - English (`en`): United States (`en-us`), Great Britain (`en-gb`)
 - Serbian (`sr`): Serbia, Cyrillic script (`sr-Cyrl-rs`), Serbia, Latin script (`sr-Latn-rs`)
+- Norwegian (`no`): Norwegian Bokmål (`nb`, `nob`), Norwegian Nynorsk (`nn`, `nno`)
 
 ## Challenges
 


### PR DESCRIPTION
# Description

Fixes #172 and #97 by adding a page on locales with a focus on their use in APIs.

## Type of PR

- Creates the article _Locale_

### Checklist:

- [ ] I have read the [contributing guidelines](contributing.md).
- [ ] I have followed the [style guide](http://machinetranslate.org/style).

## Challenges / things to improve / could use opinions on these

- Different systems represent locales a little differently, like `zhCH` vs `zh-ch` vs `zh_CH` vs `zh_ch`. I didn't mention that but tried to vary my examples a little to illustrate. Could that use a sentence?
- @cefoo suggested building the list of supported locales dynamically. That might be trickier than it seems because the data isn't as standardized as it seems, for instance Simplified Chinese is sometimes zh, sometimes zh-CN, sometimes zh-Hans. There's data using three-letter variants as well.
- I'm on the fence about mentioning languages without standard codes. That was a problem for me at Nuance when building keyboards for languages like Hinglish, which is very frequently written but does not have a language code. I can't imagine someone would use that as a MT target language though
- It's tempting to bring up Zawgyi for Burmese which isn't a script variant but a character encoding variant (it's a slight modification of Unicode). I could add that if it's valuable -- I only see it in api.yaml for one system and I'd guess the other systems _probably_ use Unicode
- Is it better to say Chinese or Mandarin for `zh`?