### PR TITLE
Fixes Events front matter

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -47,15 +47,15 @@ Based off just-the-docs v0.3.3.
     within a _script_ tag.
     {% endcomment %}
     {% capture seo_text %}{% seo %}{% endcapture %}
-    
+
     {% comment %} Extract script tag {% endcomment %}
     {% assign open_tag = '<script type="application/ld+json">' %}
     {% assign close_tag = "</script>" %}
-    
+
     {% comment %} Remove script tag and contents from `seo_text` {% endcomment %}
     {% assign extract = seo_text | split: open_tag | last | split: close_tag | first | prepend: open_tag | append: close_tag %}
     {% assign seo_text = seo_text | remove: extract %}
-    
+
     {% comment %}
     Once we've removed the default value from the script tag, we output the rest of the content
     and we apply our own -very naive- interpretation of what an JSON-LD Event looks like.
@@ -72,11 +72,12 @@ Based off just-the-docs v0.3.3.
       {% if page.seo.eventStatus %},"eventStatus": "https://schema.org/{{ page.seo.eventStatus }}"{% endif %}
       {% if page.seo.location %},"location": {
         "@type": "{{ page.seo.location.type }}",
-        {% if page.seo.location.name %},"name": "{{ page.seo.location.name }}"{% endif %}
+        {% if page.seo.location.name %}"name": "{{ page.seo.location.name }}"{% endif %}
         {% if page.seo.location.type == "PostalAddress" %}
-          {% if page.seo.location.addressCountry %},"addressCountry": "{{ page.seo.location.addressCountry }}"{% endif %}
-          {% if page.seo.location.addressLocality %},"addressLocality": "{{ page.seo.location.addressLocality }}"{% endif %}
-          {% if page.seo.location.addressRegion %},"addressRegion": "{{ page.seo.location.addressRegion }}"{% endif %}
+          {% if page.seo.location.addressCountry %}"addressCountry": "{{ page.seo.location.addressCountry }}"{% endif %}
+          {% if page.seo.location.addressLocality %}, "addressLocality": "{{ page.seo.location.addressLocality }}"{% endif %}
+          {% if page.seo.location.addressRegion %}, "addressRegion": "{{ page.seo.location.addressRegion }}"{% endif %}
+        {% elsif page.seo.location.type == "Place" %}
         {% elsif page.seo.location.type == "VirtualLocation" %}
           {% if page.seo.location.url %}"url": "{{ page.seo.location.url }}"{% endif %}
         {% endif %}
@@ -91,7 +92,7 @@ Based off just-the-docs v0.3.3.
       }{% endif %}
     }
     </script>
-    
+
   {%- endif %}
 
   {% include head_custom.html %}

--- a/events/aamt2019.md
+++ b/events/aamt2019.md
@@ -14,9 +14,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Japan
-    addressLocality: Chiyoda
+    type: Place
+    name: Chiyoda, Japan
 
   organizer:
     type: Organization

--- a/events/aamt2022.md
+++ b/events/aamt2022.md
@@ -14,12 +14,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Japan
-    addressLocality: Chiyoda
-
-    type: VirtualLocation
-    url: https://www.aamt.info/event/aamttokyo2022/
+    type: Place
+    name: Chiyoda, Japan
 
   organizer:
     type: Organization

--- a/events/ai-and-language-technologies.md
+++ b/events/ai-and-language-technologies.md
@@ -19,7 +19,8 @@ seo:
     url: https://us06web.zoom.us/webinar/register/WN_Gl7MMG-hSTWQBfVmdlry1g
 
   organizer:
-    type: Omniscien Technologies
+    type: Organization
+    name: Omniscien Technologies
     url: https://omniscien.com/
 ---
 

--- a/events/amta2020.md
+++ b/events/amta2020.md
@@ -16,7 +16,7 @@ seo:
 
   location:
     type: VirtualLocation
-    url:
+    url: https://www.softconf.com/amta2020/srw/
 
   organizer:
     type: Organization

--- a/events/amta2022.md
+++ b/events/amta2022.md
@@ -14,12 +14,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: VirtualLocation
-    url: https://web.cvent.com/event/ebca84a9-fd92-4186-a248-e4eda76bdf5e/summary
-
-    type: PostalAddress
-    addressCountry: United States of America
-    addressRegion: Florida
+    type: Place
+    name: Florida, United States of America
 
   organizer:
     type: Organization

--- a/events/at4ssl2021.md
+++ b/events/at4ssl2021.md
@@ -15,7 +15,7 @@ seo:
 
   location:
     type: VirtualLocation
-    url:
+    url: https://sites.google.com/tilburguniversity.edu/at4ssl2021/recordings
 
   organizer:
     type: Person

--- a/events/autosimtrans2020.md
+++ b/events/autosimtrans2020.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United States
-    addressRegion: Seattle
+    type: Place
+    name: Washington, US
 
   organizer:
     type: Person

--- a/events/autosimtrans2021.md
+++ b/events/autosimtrans2021.md
@@ -12,16 +12,12 @@ seo:
   description: Second Workshop on Automatic Simultaneous Translation
   startDate: 2021-06-10
   endDate: 2021-06-10
-  eventAttendanceMode: MixedEventAttendanceMode
+  eventAttendanceMode: OfflineEventAttendanceMode
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Mexico
-    addressRegion: Mexico City
-
-    type: VirtualLocation
-    url: https://zoom.us/j/94678981515?pwd=L2R4R0haanBTV2l6V1NubGExOTNRQT09
+    type: Place
+    name: Mexico City, Mexico
 
   organizer:
     type: Person

--- a/events/autosimtrans2022.md
+++ b/events/autosimtrans2022.md
@@ -15,12 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United States of America
-    addressRegion: Washington
-
-    type: VirtualLocation
-    url: https://zoom.us/j/94678981515?pwd=L2R4R0haanBTV2l6V1NubGExOTNRQT09
+    type: Place
+    name: Seattle, United States of America
 
   organizer:
     type: Person

--- a/events/convergence-2023.md
+++ b/events/convergence-2023.md
@@ -2,7 +2,7 @@
 parent: Events
 title: Convergence conference
 description: Human-machine integration in translation and interpreting
-location: hybrid
+location: online
 name: Convergence conference
 startDate: 2023-02-01
 
@@ -11,7 +11,7 @@ seo:
   name: Convergence conference
   startDate: 2023-02-01
   endDate: 2023-02-03
-  eventAttendanceMode: MixedEventAttendanceMode
+  eventAttendanceMode: OnlineEventAttendanceMode
   eventStatus: EventScheduled
 
   location:

--- a/events/eamt2020.md
+++ b/events/eamt2020.md
@@ -17,7 +17,7 @@ seo:
 
   location:
     type: VirtualLocation
-    url:
+    url: https://eamt.org
 
   organizer:
     type: Organization

--- a/events/eamt2022.md
+++ b/events/eamt2022.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Belgium
-    addressLocality: Ghent
+    type: Place
+    name: Ghent, Belgium
 
   organizer:
     type: Organization

--- a/events/eamt2023.md
+++ b/events/eamt2023.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Finland
-    addressLocality: Tampere
+    type: Place
+    name: Tampere, Finland
 
   organizer:
     type: Organization

--- a/events/events.md
+++ b/events/events.md
@@ -4,6 +4,23 @@ has_children: false
 title: Events
 description: List of machine translation events
 featured: true
+type: Events
+Events:
+  - name: MT Summit 2023
+    startDate: 2023-09-04
+    endDate: 2023-09-08
+    location:
+      name: Macau, CN
+  - name: IWSLT 2023
+    startDate: 2023-07-13
+    endDate: 2023-07-14
+    location:
+      name: Toronto, Canada
+  - name: EAMT 2023
+    startDate: 2023-06-12
+    endDate: 2023-06-15
+    location:
+      name: Tampere, Finland
 ---
 
 ## 2023

--- a/events/events.md
+++ b/events/events.md
@@ -4,7 +4,6 @@ has_children: false
 title: Events
 description: List of machine translation events
 featured: true
-type: Events
 ---
 
 ## 2023

--- a/events/events.md
+++ b/events/events.md
@@ -5,22 +5,6 @@ title: Events
 description: List of machine translation events
 featured: true
 type: Events
-Events:
-  - name: MT Summit 2023
-    startDate: 2023-09-04
-    endDate: 2023-09-08
-    location:
-      name: Macau, CN
-  - name: IWSLT 2023
-    startDate: 2023-07-13
-    endDate: 2023-07-14
-    location:
-      name: Toronto, Canada
-  - name: EAMT 2023
-    startDate: 2023-06-12
-    endDate: 2023-06-15
-    location:
-      name: Tampere, Finland
 ---
 
 ## 2023

--- a/events/hat19.md
+++ b/events/hat19.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Ireland
-    addressLocality: Dublin
+    type: Place
+    name: Dublin, Ireland
 
   organizer:
     type: Person

--- a/events/human-machine-dialectic.md
+++ b/events/human-machine-dialectic.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Belgium
-    addressLocality: Liège
+    type: Place
+    name: Liège, Belgium
 
   organizer:
     type: Organization

--- a/events/iwslt2022.md
+++ b/events/iwslt2022.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Ireland
-    addressLocality: Dublin
+    type: Place
+    name: Dublin, Ireland
 
   organizer:
     type: Person

--- a/events/iwslt2023.md
+++ b/events/iwslt2023.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Canada
-    addressLocality: Toronto
+    type: Place
+    name: Toronto, Canada
 
   organizer:
     type: Person

--- a/events/lay-use-and-perceptions-of-machine-translation.md
+++ b/events/lay-use-and-perceptions-of-machine-translation.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Ireland
-    addressLocality: Dublin
+    type: Place
+    name: Dublin, Ireland
 
   organizer:
     type: Organization

--- a/events/lit-translation-and-ai.md
+++ b/events/lit-translation-and-ai.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: France
-    addressLocality: Paris
+    type: Place
+    name: Paris, France
 
   organizer:
     type: Organization

--- a/events/loresmt2021.md
+++ b/events/loresmt2021.md
@@ -16,7 +16,7 @@ seo:
 
   location:
     type: VirtualLocation
-    url:
+    url: https://sites.google.com/view/loresmt/
 
   organizer:
     type: Person

--- a/events/loresmt2022.md
+++ b/events/loresmt2022.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Republic of Korea
-    addressLocality: Gyeongju
+    type: Place
+    name: Gyeongju, Republic of Korea
 
   organizer:
     type: Online

--- a/events/machine-translation-meetup-1.md
+++ b/events/machine-translation-meetup-1.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United States
-    addressLocality: Menlo Park
+    type: Place
+    name: Menlo Park, United States
 
   organizer:
     type: Organization

--- a/events/machine-translation-meetup-2.md
+++ b/events/machine-translation-meetup-2.md
@@ -5,6 +5,7 @@ description: Meetup organised by Machine Translate
 location: online
 startDate: 2022-10-21
 name: Machine translation meetup 2
+
 seo:
   type: Event
   name: Machine translation meetup 2
@@ -15,8 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-  type: VirtualLocation
-  url: https://www.meetup.com/machinetranslate/events/289057267/
+    type: VirtualLocation
+    url: https://www.meetup.com/machinetranslate/events/289057267/
 
   organizer:
     type: Organization

--- a/events/massively-multilingual-conference-expo.md
+++ b/events/massively-multilingual-conference-expo.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-  type: PostalAddress
-  addressCountry: US
-  addressLocality: California
+    type: Place
+    naame: California, US
 
   organizer:
     type: Organization

--- a/events/mtm2019.md
+++ b/events/mtm2019.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Scotland
-    addressLocality: Edinburgh
+    type: Place
+    name: Edinburgh, Scotland
 
   organizer:
     type: Person

--- a/events/mtm2022.md
+++ b/events/mtm2022.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Czech Republic
-    addressLocality: Prague
+    type: Place
+    name: Prague, Czech Republic
 
   organizer:
     type: Organization

--- a/events/mtma2022.md
+++ b/events/mtma2022.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United States of America
-    addressLocality: Redmond
+    type: Place
+    name: Redmond, United States of America
 
   organizer:
     type: Person

--- a/events/mtsummit2015.md
+++ b/events/mtsummit2015.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United States of America
-    addressLocality: Florida
+    type: Place
+    name: Florida, United States of America
 
   organizer:
     type: Organization

--- a/events/mtsummit2017.md
+++ b/events/mtsummit2017.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Japan
-    addressLocality: Nagoya
+    type: Place
+    name: Nagoya, Japan
 
   organizer:
     type: Organization

--- a/events/mtsummit2019.md
+++ b/events/mtsummit2019.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Ireland
-    addressLocality: Dublin
+    type: Place
+    name: Dublin, Ireland
 
   organizer:
     type: Organization

--- a/events/mtsummit2021.md
+++ b/events/mtsummit2021.md
@@ -17,6 +17,7 @@ seo:
 
   location:
     type: VirtualLocation
+    url: https://amtaweb.org
 
   organizer:
     type: Organization

--- a/events/mtsummit2023.md
+++ b/events/mtsummit2023.md
@@ -22,6 +22,7 @@ seo:
     type: Organization
     name: Asian-Pacific Association for Machine Translation
     url: https://aamt.info/
+
 ---
 
 The nineteenth Machine Translation Summit 2023 (**MTS 2023**) will take place from 4 September to 8 September in Macau Special Administrative Region, China.

--- a/events/mumttt2022.md
+++ b/events/mumttt2022.md
@@ -14,9 +14,13 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Spain
-    addressLocality: Malaga
+    type: Place
+    name: Malaga, Spain
+
+  organizer:
+    type: Organization
+    name: EUROPHRAS
+    url: http://machinetranslate.org/mumttt2022.md#organising-committee
 ---
 
 The 5th Workshop on Multi-word Units in Machine Translation and Translation Technology (**MUMTTT 2022**) was held in conjunction with the International Conference “Computational and Corpus-based Phraseology”.

--- a/events/nettt2022.md
+++ b/events/nettt2022.md
@@ -16,9 +16,13 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Greece
-    addressLocality: Rhodes
+    type: Place
+    name: Rhodes, Greece
+
+  organizer:
+    type: Organization
+    name: NeTTT
+    url: http://machinetranslate.org/nettt2022.md#organisers
 ---
 
 The first New Trends in Translation and Technology (**NeTTT**) conference took place in Rhodes, Greece, from 2 July to 6 July, 2022.

--- a/events/nmt-foundations-applications-implications.md
+++ b/events/nmt-foundations-applications-implications.md
@@ -1,9 +1,9 @@
 ---
 parent: Events
-title: Neural Machine Translation – Foundations, Applications and Implications
+title: "Neural Machine Translation – Foundations, Applications and Implications"
 description: IATIS Training Event on Neural Machine Translation
 location: online
-name: Neural Machine Translation – Foundations, Applications and Implications
+name: "Neural Machine Translation – Foundations, Applications and Implications"
 startDate: 2022-04-21
 
 seo:
@@ -17,10 +17,12 @@ seo:
 
   location:
   type: VirtualLocation
+  url: https://www.th-koeln.de/informations-und-kommunikationswissenschaften/iatis-training-event-neural-machine-translation--foundations-applications-and-implications_87375.php
 
   organizer:
     type: Organization
     name: International Association for Translation and Intercultural Studies, Institute of Translation and Multilingual Communication
+    url: https://www.th-koeln.de/informations-und-kommunikationswissenschaften/iatis-training-event-neural-machine-translation--foundations-applications-and-implications_87375.php
 ---
 
 

--- a/events/pslt2021.md
+++ b/events/pslt2021.md
@@ -16,6 +16,7 @@ seo:
 
   location:
     type: VirtualLocation
+    url: http://www.aamtjapio.com/pslt2021/
 
   organizer:
     type: Person

--- a/events/tc44.md
+++ b/events/tc44.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Luxembourg
-    addressLocality: Luxembourg City
+    type: Place
+    name: Luxembourg City, Luxembourg
 
   organizer:
     type: Person

--- a/events/tq2022.md
+++ b/events/tq2022.md
@@ -16,10 +16,12 @@ seo:
 
   location:
     type: VirtualLocation
+    url: https://tq2022.sciencesconf.org/
 
   organizer:
     type: Organization
     name: Université de Lille; UMR Savoirs, Textes, Langage of CNRS
+    url: https://tq2022.sciencesconf.org/
 ---
 
 The #TQ2022 : Traduction & Qualité, « Comment enseigner (avec) la traduction automatique ? » (**TQ2022**) conference was held online on 28 January, 2022.

--- a/events/tqeape.md
+++ b/events/tqeape.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United States
-    addressLocality: Boston
+    type: Place
+    name: Boston, United States
 
   organizer:
     type: Person

--- a/events/wat2021.md
+++ b/events/wat2021.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Thailand
-    addressRegion: Bangkok
+    type: Place
+    name: Bangkok, Thailand
 
   organizer:
     type: Organization

--- a/events/wat2022.md
+++ b/events/wat2022.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Republic of Korea
-    addressLocality: Gyeongju
+    type: Place
+    name: Gyeongju, Republic of Korea
 
   organizer:
     type: Person

--- a/events/wmt06.md
+++ b/events/wmt06.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United States of America
-    addressLocality: New York
+    type: Place
+    name: New York, United States of America
 
   organizer:
     type: Person

--- a/events/wmt07.md
+++ b/events/wmt07.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Prague
-    addressLocality: Czech Republic
+    type: Place
+    name: Prague, Czech Republic
 
   organizer:
     type: Person

--- a/events/wmt08.md
+++ b/events/wmt08.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Unites States of America
-    addressLocality: Columbus
+    type: Place
+    name: Columbus, Unites States of America
 
   organizer:
     type: Person

--- a/events/wmt09.md
+++ b/events/wmt09.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Greece
-    addressLocality: Athens
+    type: Place
+    name: Athens, Greece
 
   organizer:
     type: Person

--- a/events/wmt10.md
+++ b/events/wmt10.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Sweden
-    addressLocality: Uppsala
+    type: Place
+    name: Uppsala, Sweden
 
   organizer:
     type: Person

--- a/events/wmt11.md
+++ b/events/wmt11.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United Kingdom
-    addressLocality: Edinburgh
+    type: Place
+    name: Edinburgh, United Kingdom
 
   organizer:
     type: Person

--- a/events/wmt12.md
+++ b/events/wmt12.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Canada
-    addressLocality: Quebec
+    type: Place
+    name: Quebec, Canada
 
   organizer:
     type: Person

--- a/events/wmt13.md
+++ b/events/wmt13.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Bulgaria
-    addressLocality: Sofia
+    type: Place
+    name: Sofia, Bulgaria
 
   organizer:
     type: Person

--- a/events/wmt14.md
+++ b/events/wmt14.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United States of America
-    addressLocality: Maryland
+    type: Place
+    name: Maryland, United States of America
 
   organizer:
     type: Person

--- a/events/wmt15.md
+++ b/events/wmt15.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Portugal
-    addressLocality: Lisbon
+    type: Place
+    name: Lisbon, Portugal
 
   organizer:
     type: Person

--- a/events/wmt16.md
+++ b/events/wmt16.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Germany
-    addressLocality: Berlin
+    type: Place
+    name: Berlin, Germany
 
   organizer:
     type: Person

--- a/events/wmt17.md
+++ b/events/wmt17.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Denmark
-    addressLocality: Copenhagen
+    type: Place
+    name: Copenhagen, Denmark
 
   organizer:
     type: Person

--- a/events/wmt18.md
+++ b/events/wmt18.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Belgium
-    addressLocality: Brussels
+    type: Place
+    name: Brussels, Belgium
 
   organizer:
     type: Person

--- a/events/wmt19.md
+++ b/events/wmt19.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Italy
-    addressLocality: Florence
+    type: Place
+    name: Florence, Italy
 
   organizer:
     type: Person

--- a/events/wmt20.md
+++ b/events/wmt20.md
@@ -17,6 +17,7 @@ seo:
 
   location:
     type: VirtualLocation
+    url: https://www.statmt.org/wmt20/
 
   organizer:
     type: Person

--- a/events/wmt21.md
+++ b/events/wmt21.md
@@ -14,9 +14,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-  type: PostalAddress
-  addressCountry: Dominican Republic
-  addressRegion: LaAltagracia
+  type: Place
+  name: LaAltagracia, Dominican Republic
 
   organizer:
     type: Person

--- a/events/wmt22.md
+++ b/events/wmt22.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: United Arab Emirates
-    addressLocality: Abu Dhabi
+    type: Place
+    name: Abu Dhabi, United Arab Emirates
 
   organizer:
     type: Person

--- a/events/wnmt17.md
+++ b/events/wnmt17.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Canada
-    addressLocality: Vancouver
+    type: Place
+    name: Vancouver, Canada
 
   organizer:
     type: Person

--- a/events/wnmt18.md
+++ b/events/wnmt18.md
@@ -16,9 +16,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Australia
-    addressLocality: Melbourne
+    type: Place
+    name: Melbourne, Australia
 
   organizer:
     type: Person

--- a/events/zurich-1.md
+++ b/events/zurich-1.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Switzerland
-    addressLocality: Zurich
+    type: Place
+    addressCountry: Zurich, Switzerland
 ---
 
 The first **Machine Translation Meetup** (**MTM**) took place on 19 April, 2018, in Zurich, Switzerland.

--- a/events/zurich-10.md
+++ b/events/zurich-10.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Switzerland
-    addressLocality: Zurich
+    type: Place
+    name: Zurich, Switzerland
 ---
 
 The tenth **Machine Translation Meetup** (**MTM**) took place on 13 June, 2022, in Zurich, Switzerland.

--- a/events/zurich-11.md
+++ b/events/zurich-11.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Switzerland
-    addressLocality: Zurich
+    type: Place
+    name: Zurich, Switzerland
 ---
 
 The eleventh **Machine Translation Meetup** (**MTM**) took place on 12 December, 2022, in Zurich, Switzerland.

--- a/events/zurich-2.md
+++ b/events/zurich-2.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Switzerland
-    addressLocality: Zurich
+    type: Place
+    addressCountry: Zurich, Switzerland
 ---
 
 The second **Machine Translation Meetup** (**MTM**) took place on 22 October, 2018, in Zurich, Switzerland.

--- a/events/zurich-3.md
+++ b/events/zurich-3.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Switzerland
-    addressLocality: Zurich
+    type: Place
+    addressCountry: Zurich, Switzerland
 ---
 
 The third **Machine Translation Meetup** (**MTM**) took place on 15 January, 2019, in Zurich, Switzerland.

--- a/events/zurich-4.md
+++ b/events/zurich-4.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Switzerland
-    addressLocality: Zurich
+    type: Place
+    addressCountry: Zurich, Switzerland
 ---
 
 The fourth **Machine Translation Meetup** (**MTM**) took place on 3 June, 2019, in Zurich, Switzerland.

--- a/events/zurich-5.md
+++ b/events/zurich-5.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Switzerland
-    addressLocality: Zurich
+    type: Place
+    addressCountry: Zurich, Switzerland
 ---
 
 The fifth **Machine Translation Meetup** (**MTM**) took place on 28 October, 2019, in Zurich, Switzerland.

--- a/events/zurich-6.md
+++ b/events/zurich-6.md
@@ -15,9 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    addressCountry: Switzerland
-    addressLocality: Zurich
+    type: Place
+    addressCountry: Zurich, Switzerland
 ---
 
 The sixth **Machine Translation Meetup** (**MTM**) took place on 3 February, 2021, in Zurich, Switzerland.

--- a/events/zurich-7.md
+++ b/events/zurich-7.md
@@ -16,6 +16,7 @@ seo:
 
   location:
     type: VirtualLocation
+    url: https://www.meetup.com/Machine-Translation-Meetup-MTM/events/270311951/
 ---
 
 The seventh **Machine Translation Meetup** (**MTM**) took place online on 19 May, 2020.

--- a/events/zurich-9.md
+++ b/events/zurich-9.md
@@ -15,11 +15,8 @@ seo:
   eventStatus: EventScheduled
 
   location:
-    type: PostalAddress
-    streetAddress: Viaduktstrasse 93
-    addressCountry: Switzerland
-    addressLocality: Zurich
-    addressRegion: Zurich
+    type: Place
+    name: Zurich, Switzerland
 ---
 
 The ninth **Machine Translation Meetup** (**MTM**) took place on 25 October, 2021, in Zurich, Switzerland.


### PR DESCRIPTION
# Description

This PR fixes events front matter.
The events front matter contained an error in the `location` variable.

When `location` is a **physical place**, but the **address is not known**, the code should be as follows:

```
location:
  type: Place
  name: Washington, US
```

When `location` is a **physical place** and the **address is known**. the code should be as follows:

```
location:
  type: PostalAddress
  streetAddress: 123 Main Street
  addressLocality: Seattle
  addressCountry: US
```

When `location` is **online**, the code should be as follows:

```
location:
    type: VirtualLocation
    url: https://zoom.us[...]
```

## Important:

All these variables are mandatory.  Failure to include any of them or leaving the value empty will render the front matter not eligible for Google Rich Results.


## Type of PR

- Edits event pages


### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
