### PR TITLE
Create: Zero-shot translation

### DIFF
--- a/applications/advanced-concepts/bridging.md
+++ b/applications/advanced-concepts/bridging.md
@@ -4,7 +4,7 @@ title: Bridging
 description: Two-step translation through an intermediate language
 ---
 
-**Bridging** uses an intermediate language to translate between source and target languages.
+**Bridging** is a machine translation method that uses an intermediate language to translate between source and target languages.
 If a language pair `(source, target)` is desired, bridging translates twice: `(source, bridge)`, then `(bridge, target)`. 
 The `bridge` language is also called a pivot language. 
 

--- a/applications/advanced-concepts/bridging.md
+++ b/applications/advanced-concepts/bridging.md
@@ -1,0 +1,16 @@
+---
+parent: Building and research
+title: Bridging
+description: Two-step translation through an intermediate language
+---
+
+**Bridging** uses an intermediate language to translate between source and target languages.
+If a language pair `(source, target)` is desired, bridging translates twice: `(source, bridge)`, then `(bridge, target)`. 
+The `bridge` language is also called a pivot language. 
+
+English is a common choice for the bridge because many languages have training data with English.
+
+## Applications
+
+- Translation without parallel data
+- Paraphrasing in a single language

--- a/applications/advanced-concepts/bridging.md
+++ b/applications/advanced-concepts/bridging.md
@@ -12,5 +12,5 @@ English is a common choice for the bridge because many languages have training d
 
 ## Applications
 
-- Translation without parallel data
+- Translation without [parallel data](/customisation/parallel-data.md)
 - Paraphrasing in a single language

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -4,21 +4,22 @@ title: Zero-shot translation
 description: Machine translation without parallel training data
 ---
 
-**Zero-shot machine translation** is machine translation that is trained without parallel data between the source and target languages.
+**Zero-shot machine translation** is trained without parallel data between the source and target languages.
 Zero-shot translation is desireable because it can be prohibitively time-consuming or costly to build a training corpus of parallel texts to build a normal translation model for each pair of languages.
 
 Zero-shot machine translation is an active area of research, and models are typically lower quality than supervised translation models.
 
 ## Approaches
 
-- Multilingual machine translation: Rather than learn one model per language pair, this approach learns a single model for all language pairs. The target langauge is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other.
-- Pivoting/bridging: If a language pair (a, c) is desired, this approach translates twice: (a, b), then (b, c) where b is called the pivot or bridge language. English is a common choice for the pivot because there's often parallel data with English.
-- Denoising autoencoders: This approach trains two denoising autoencoders on monolingual data, one for the source language and one for the target language. Then the encoder from the source language is connected to the decoder for the target language in the hope that the latent representations of the two are similar.
+- Bridging: If a language pair (a, c) is desired, this approach translates twice: (a, b), then (b, c) where b is called the pivot or bridge language. English is a common choice for the pivot because many languages have training data with English.
+- Multilingual neural machine translation: This approach learns a single model for all language pairs. The target langauge is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. 
 
 ## Related
 
 - Cross-lingual fine-tuning
 - Adversarial training
+- Denoising autoencoders: This approach trains two denoising autoencoders on monolingual data, one for the source language and one for the target language. Then the encoder from the source language is connected to the decoder for the target language in the hope that the latent representations of the two are similar.
+
 
 ## TODO
 

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -13,7 +13,7 @@ Zero-shot machine translation is an active area of research.
 
 ## Approaches
 
-- Multilingual [neural machine translation](/approaches/neural-machine-translation.md) (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other.
+- Multilingual [neural machine translation](/approaches/neural-machine-translation.md) (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. As of 2022, [Google Translate uses MNMT](https://ai.googleblog.com/2022/05/24-new-languages-google-translate.html).
 - Stitching together encoders and decoders
     - When training models for many language pairs, it's possible to ensure that the latent representations are similar across languages, then connect the appropriate encoder and decoder for the desired language pair.
     - Unsupervised methods learn encoders and decoders as denoising autoencoders, making effort to ensure that the latent representations are similar across languages, then connect the appropriate encoder and decoder for the desired language pair.

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -13,10 +13,9 @@ Zero-shot machine translation is an active area of research.
 
 ## Approaches
 
-- Bridging: If a language pair `(source, target)` is desired, this approach translates twice: `(source, bridge)`, then `(bridge, target)`. The `bridge` language is also called a pivot language. English is a common choice for the pivot because many languages have training data with English.
 - Multilingual [neural machine translation](/approaches/neural-machine-translation.md) (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. 
 - Transfer learning: These approaches connect an encoder for the source language to a decoder for the target language. Algorithms are developed to align the latent representations of encoders and decoders across languages.
 
 ## See also
 
-- Bridging: Bridging is also commonly used to translate between languages without parallel data.
+- [Bridging](bridging.md): Bridging is also commonly used to translate between languages without parallel data.

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -13,6 +13,6 @@ Zero-shot models are typically lower quality than supervised translation models.
 ## Approaches
 
 - Bridging: If a language pair `(source, target)` is desired, this approach translates twice: `(source, bridge)`, then `(bridge, target)`. The `bridge` language is also called a pivot language. English is a common choice for the pivot because many languages have training data with English.
-- Multilingual neural machine translation (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. 
-- Transfer learning: This group of approaches connects an encoder for the source language to a decoder for the target language. Algorithms are developed to align the latent representations of encoders and decoders across languages.
+- Multilingual [neural machine translation](/approaches/neural-machine-translation.md) (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. 
+- Transfer learning: These approaches connect an encoder for the source language to a decoder for the target language. Algorithms are developed to align the latent representations of encoders and decoders across languages.
 

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -6,6 +6,7 @@ description: Machine translation without parallel training data
 
 **Zero-shot machine translation** is translation without parallel data between the source and target languages.
 Zero-shot translation is desirable because it can be too costly to create training data for each language pair.
+The term zero-shot is a reference to [zero-shot learning](https://en.wikipedia.org/wiki/Zero-shot_learning).
 
 Zero-shot machine translation is an active area of research.
 Zero-shot models are typically lower quality than supervised translation models.

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -6,10 +6,10 @@ description: Machine translation without parallel training data
 
 **Zero-shot machine translation** is translation without parallel data between the source and target languages.
 Zero-shot translation is desirable because it can be too costly to create training data for each language pair.
+However, zero-shot models are typically lower quality than models trained from parallel data.
 The term zero-shot is a reference to [zero-shot learning](https://en.wikipedia.org/wiki/Zero-shot_learning).
 
 Zero-shot machine translation is an active area of research.
-Zero-shot models are typically lower quality than supervised translation models.
 
 ## Approaches
 

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -7,7 +7,8 @@ description: Machine translation without parallel training data
 **Zero-shot machine translation** is translation without parallel data between the source and target languages.
 Zero-shot translation is desirable because it can be too costly to create training data for each language pair.
 
-Zero-shot machine translation is an active area of research, and models are typically lower quality than supervised translation models.
+Zero-shot machine translation is an active area of research.
+Zero-shot models are typically lower quality than supervised translation models.
 
 ## Approaches
 

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -13,8 +13,10 @@ Zero-shot machine translation is an active area of research.
 
 ## Approaches
 
-- Multilingual [neural machine translation](/approaches/neural-machine-translation.md) (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. 
-- Transfer learning: These approaches connect an encoder for the source language to a decoder for the target language. Algorithms are developed to align the latent representations of encoders and decoders across languages.
+- Multilingual [neural machine translation](/approaches/neural-machine-translation.md) (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other.
+- Stitching together encoders and decoders
+    - When training models for many language pairs, it's possible to ensure that the latent representations are similar across languages, then connect the appropriate encoder and decoder for the desired language pair.
+    - Unsupervised methods learn encoders and decoders as denoising autoencoders, making effort to ensure that the latent representations are similar across languages, then connect the appropriate encoder and decoder for the desired language pair.
 
 ## See also
 

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -1,0 +1,28 @@
+---
+parent: Building and research
+title: Zero-shot translation
+description: Machine translation without parallel training data
+---
+
+**Zero-shot machine translation** is machine translation that is trained without parallel data between the source and target languages.
+Zero-shot translation is desireable because it can be prohibitively time-consuming or costly to build a training corpus of parallel texts to build a normal translation model for each pair of languages.
+
+Zero-shot machine translation is an active area of research, and models are typically lower quality than supervised translation models.
+
+## Approaches
+
+- Multilingual machine translation: Rather than learn one model per language pair, this approach learns a single model for all language pairs. The target langauge is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other.
+- Pivoting/bridging: If a language pair (a, c) is desired, this approach translates twice: (a, b), then (b, c) where b is called the pivot or bridge language. English is a common choice for the pivot because there's often parallel data with English.
+- Denoising autoencoders: This approach trains two denoising autoencoders on monolingual data, one for the source language and one for the target language. Then the encoder from the source language is connected to the decoder for the target language in the hope that the latent representations of the two are similar.
+
+## Related
+
+- Cross-lingual fine-tuning
+- Adversarial training
+
+## TODO
+
+- Clarify the data needs of the approaches: MNMT and pivoting still require some parallel data of the language, they just don't need the (source, target) pair
+- Introduce the term unsupervised MT for denoising AEs -- there's an issue open for a page on this
+- It'd be nice to give a sense of the quality of zero-shot compared to supervised approaches
+- It'd be nice to answer a question like "Should I use zero-shot MT?" or offer some guidance on when to use which type of approach, though that may be better suited for the "How to get machine translation for your language" issue

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -4,26 +4,14 @@ title: Zero-shot translation
 description: Machine translation without parallel training data
 ---
 
-**Zero-shot machine translation** is trained without parallel data between the source and target languages.
-Zero-shot translation is desireable because it can be prohibitively time-consuming or costly to build a training corpus of parallel texts to build a normal translation model for each pair of languages.
+**Zero-shot machine translation** is translation without parallel data between the source and target languages.
+Zero-shot translation is desirable because it can be too costly to create training data for each language pair.
 
 Zero-shot machine translation is an active area of research, and models are typically lower quality than supervised translation models.
 
 ## Approaches
 
-- Bridging: If a language pair (a, c) is desired, this approach translates twice: (a, b), then (b, c) where b is called the pivot or bridge language. English is a common choice for the pivot because many languages have training data with English.
-- Multilingual neural machine translation: This approach learns a single model for all language pairs. The target langauge is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. 
+- Bridging: If a language pair `(source, target)` is desired, this approach translates twice: `(source, bridge)`, then `(bridge, target)`. The `bridge` language is also called a pivot language. English is a common choice for the pivot because many languages have training data with English.
+- Multilingual neural machine translation (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. 
+- Transfer learning: This group of approaches connects an encoder for the source language to a decoder for the target language. Algorithms are developed to align the latent representations of encoders and decoders across languages.
 
-## Related
-
-- Cross-lingual fine-tuning
-- Adversarial training
-- Denoising autoencoders: This approach trains two denoising autoencoders on monolingual data, one for the source language and one for the target language. Then the encoder from the source language is connected to the decoder for the target language in the hope that the latent representations of the two are similar.
-
-
-## TODO
-
-- Clarify the data needs of the approaches: MNMT and pivoting still require some parallel data of the language, they just don't need the (source, target) pair
-- Introduce the term unsupervised MT for denoising AEs -- there's an issue open for a page on this
-- It'd be nice to give a sense of the quality of zero-shot compared to supervised approaches
-- It'd be nice to answer a question like "Should I use zero-shot MT?" or offer some guidance on when to use which type of approach, though that may be better suited for the "How to get machine translation for your language" issue

--- a/applications/advanced-concepts/zero-shot-translation.md
+++ b/applications/advanced-concepts/zero-shot-translation.md
@@ -17,3 +17,6 @@ Zero-shot machine translation is an active area of research.
 - Multilingual [neural machine translation](/approaches/neural-machine-translation.md) (MNMT): This approach learns a single model for all language pairs. The target language is an input to the model. This approach can produce translations between languages that both have parallel data, but not necessarily parallel data with each other. 
 - Transfer learning: These approaches connect an encoder for the source language to a decoder for the target language. Algorithms are developed to align the latent representations of encoders and decoders across languages.
 
+## See also
+
+- Bridging: Bridging is also commonly used to translate between languages without parallel data.

--- a/roadmap.md
+++ b/roadmap.md
@@ -47,7 +47,7 @@ description: Content roadmap for Machine Translate
 - ~~[User-generated content](/applications/user-generated-content.md)~~
 - [Website translation \[#160\]](https://github.com/machinetranslate/machinetranslate.org/issues/160)
 - [Unsupervised machine translation \[#132\]](https://github.com/machinetranslate/machinetranslate.org/issues/132)
-- [Zero-shot machine translation \[#133\]](https://github.com/machinetranslate/machinetranslate.org/issues/133)
+- ~~[Zero-shot machine translation \[#133\]](https://github.com/machinetranslate/machinetranslate.org/issues/133)~~
 
 ### - ~~[Products](/industry/products.md)~~
 


### PR DESCRIPTION
# Description

Fixes #133 by adding an article on zero-shot translation

## Type of PR

- Creates the article _Zero-shot translation_

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).

## Challenges -- Could use advice

- I did a fairly quick literature review on this one, so the list of approaches may need updating. 
- I think I saw mention in papers of training encoder and decoder on monolingual data and finding a way to align the latent representations. I tried to word the transfer learning bullet to cover that, but it's not really the best name.
- I would've loved to indicate the general success of each approach but didn't have time for a full lit review to do it. I got the impression that bridging is generally better quality and more reliable than MNMT but also that systems are evaluated in unrealistic conditions by just omitting some data from high-resource language pairs, when the appeal of it is more for low-resource languages or to simplify the MLops of supporting many language pairs.