### PR TITLE
Add training data article

### DIFF
--- a/customisation/training-data.md
+++ b/customisation/training-data.md
@@ -6,7 +6,7 @@ description: Training data for machine translation
 ---
 
 **Training data** is the data used to train a model.
-In other words, the parameters of the model are set by running a training algorithm on training data.
+In other words, the training algorithm sets the model parameters to fit the training data.
 
 The most common type of training data in machine translation is [parallel text data](parallel-data.md).
 Monolingual text data is also often used for learning, for instance in [language models](/concepts/language-model.md) or [back-translating](/customisation/back-translation.md) the monolingual data to generate synthetic parallel data.

--- a/customisation/training-data.md
+++ b/customisation/training-data.md
@@ -5,6 +5,8 @@ title: Training data
 description: Training data for machine translation
 ---
 
-**Training data** is the data used for learning model parameters.
+**Training data** is the data used to train a model.
+In other words, the parameters of the model are set by running a training algorithm on training data.
+
 The most common type of training data in machine translation is [parallel text data](parallel-data.md).
 Monolingual text data is also often used for learning, for instance in [language models](/concepts/language-model.md) or [back-translating](/customisation/back-translation.md) the monolingual data to generate synthetic parallel data.

--- a/customisation/training-data.md
+++ b/customisation/training-data.md
@@ -1,7 +1,10 @@
 ---
 grand_parent: Building and research
 parent: Customisation
-layout: coming_soon
 title: Training data
-description: Training data for customising machine translation
+description: Training data for machine translation
 ---
+
+**Training data** is the data used for learning model parameters.
+The most common type of training data in machine translation is [parallel text data](parallel-data.md).
+Monolingual text data is also often used for learning, for instance in [language models](/concepts/language-model.md) or [back-translating](/customisation/back-translation.md) the monolingual data to generate synthetic parallel data.


### PR DESCRIPTION
# Description

Fixes #136 by filling out the training data page. I kept it pretty basic. 

The only challenge I saw was that it felt somewhat circular to say that training data is used for training, so I tried to explain the idea training very minimally.

## Type of PR

- Edits _Training data_


### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
