### PR TITLE
Add sentence splitting

### DIFF
--- a/concepts/sentence-splitting.md
+++ b/concepts/sentence-splitting.md
@@ -4,3 +4,8 @@ parent: Concepts
 title: Sentence splitting
 description: Splitting a text into a sequence of sentences
 ---
+
+**Sentence splitting** is the process of converting a text into a sequence of sentences.
+Sentence splitting is an essential step in machine translation to build [parallel data](/customisation/parallel-data.md) that is [aligned](/customisation/alignment.md) at the sentence level.
+Alignment at the sentence level is necessary in machine translation to make training efficient.
+

--- a/concepts/sentence-splitting.md
+++ b/concepts/sentence-splitting.md
@@ -9,3 +9,6 @@ description: Splitting a text into a sequence of sentences
 Sentence splitting is an essential step in machine translation to build [parallel data](/customisation/parallel-data.md) that is [aligned](/customisation/alignment.md) at the sentence level.
 Alignment at the sentence level is necessary in machine translation to make training efficient.
 
+Common approaches to sentence splitting include rules such as regular expressions and machine learning models.
+
+Sentence splitting is also called sentence segmentation or sentence boundary detection.

--- a/concepts/sentence-splitting.md
+++ b/concepts/sentence-splitting.md
@@ -1,0 +1,6 @@
+---
+grand_parent: Resources
+parent: Concepts
+title: Sentence splitting
+description: Splitting a text into a sequence of sentences
+---


### PR DESCRIPTION
# Description

Fixes #174 by adding an article on sentence splitting

## Challenges - could use some perspectives on this

- A beginner would probably want to know why we split into sentences. I tried to briefly explain it but didn't do the best job (I just said it's for efficiency, which is true but glosses over details). More than anything sentence splitting feels like a good compromise between making it easy/fast for MT to learn and not needing to do tons of annotation work. Alignment at the word level might enable better MT but would probably take ages to annotate, and would likely be very noisy. Alignment at the document level is less work but MT needs to consider so many more possible word-level alignments (though it's fairly common, just with a sentence alignment stage first).
- I didn't want to get too much into depth about challenges in segmentation or various algorithms

## Type of PR

- Creates the article _Sentence splitting_

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
