### PR TITLE
Add Dari Persian, and related language groupings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 _site
 .sass-cache
 .jekyll-cache

--- a/_data/api-language.yml
+++ b/_data/api-language.yml
@@ -13,7 +13,7 @@ microsoft:
   iw: he # Legacy, Google
   jw: jv # Legacy, Google
   fa-prs: fa-af  # Macrolanguage, Apptek for Dari Persian
-  prs: fa-af # Macrolanguage, Amazon, Apptek, Language Weaver, Lilt, Microsoft, Systran for Dari Persian
+  prs: fa-af # Macrolanguage, Language Weaver, Lilt, Microsoft, Systran for Dari Persian
   fil: tl # Macrolanguage, Microsoft for Tagalog
   mww: hmn # Macrolanguage, Microsoft for Hmong
   cz: cs # Czech, Omniscien

--- a/_data/api-language.yml
+++ b/_data/api-language.yml
@@ -12,8 +12,8 @@ microsoft:
   in: id # Legacy, Google
   iw: he # Legacy, Google
   jw: jv # Legacy, Google
-  fa-prs: fa-af  # Macrolanguage, Apptek for Dari
-  prs: fa-af # Macrolanguage, Microsoft for Dari
+  fa-prs: fa-af  # Macrolanguage, Apptek for Dari Persian
+  prs: fa-af # Macrolanguage, Amazon, Apptek, Language Weaver, Lilt, Microsoft, Systran for Dari Persian
   fil: tl # Macrolanguage, Microsoft for Tagalog
   mww: hmn # Macrolanguage, Microsoft for Hmong
   cz: cs # Czech, Omniscien

--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -13,6 +13,7 @@
 -
   codes: [ af, afr ]
   names: [ Afrikaans ]
+  variant_names: [ 'Kaaps', 'Afrikaaps' ]
   family: [ gem, ine ]
   scripts: [ Latn ]
   typology:
@@ -995,7 +996,8 @@
 
 -
   codes: [ nl, nld, dut ]
-  names: [ Dutch ]
+  names: [ Dutch, Netherlandic ]
+  variant_names: [ Hollandic, Flemish, Surinamese ]
   family: [ gem, ine ]
   scripts: [ Latn ]
   typology:

--- a/_data/related-languages.yml
+++ b/_data/related-languages.yml
@@ -5,8 +5,8 @@
   name: Persian
   languages: [ fa, prs, to ]
 -
-  name: Netherlandic
-  languages: [ nl, af ]
+  name: Low Franconian
+  languages: [ nl, af, li, vls, zea ]
 -
   name: Oghuz Turkish
   languages: [ tr, az ]
@@ -21,8 +21,7 @@
   languages: [ ku, ckb, zza ]
 -
   name: Mari
-  languages: [ mrj, mhr  ]
+  languages: [ mrj, mhr ]
 -
   name: Hindustani
   languages: [ hi, ur ]
--

--- a/_data/related-languages.yml
+++ b/_data/related-languages.yml
@@ -1,0 +1,28 @@
+-
+  name: Serbo-Croatian
+  languages: [ sr, hr, bs, cnr ]
+-
+  name: Persian
+  languages: [ fa, prs, to ]
+-
+  name: Netherlandic
+  languages: [ nl, af ]
+-
+  name: Oghuz Turkish
+  languages: [ tr, az ]
+-
+  name: Malay
+  languages: [ id, ms ]
+-
+  name: Arabic
+  languages: [ mt, ar ]
+-
+  name: Kurdish
+  languages: [ ku, ckb, zza ]
+-
+  name: Mari
+  languages: [ mrj, mhr  ]
+-
+  name: Hindustani
+  languages: [ hi, ur ]
+-

--- a/apis/amazon.md
+++ b/apis/amazon.md
@@ -127,7 +127,7 @@ supported_languages:
   normalized_code: fa-af
   base_code: fa
   name: Persian
-  variant_name: null
+  variant_name: Dari
 - slug: finnish
   code: fi
   normalized_code: fi

--- a/apis/apptek.md
+++ b/apis/apptek.md
@@ -125,7 +125,7 @@ supported_languages:
   normalized_code: fa-af
   base_code: fa
   name: Persian
-  variant_name: null
+  variant_name: Dari
 - slug: finnish
   code: fi
   normalized_code: fi

--- a/apis/language-weaver.md
+++ b/apis/language-weaver.md
@@ -240,7 +240,7 @@ supported_languages:
   normalized_code: fa-af
   base_code: fa
   name: Persian
-  variant_name: null
+  variant_name: Dari
 - slug: pashto
   code: ps
   normalized_code: ps

--- a/apis/lilt.md
+++ b/apis/lilt.md
@@ -209,7 +209,7 @@ supported_languages:
   normalized_code: fa-af
   base_code: fa
   name: Persian
-  variant_name: null
+  variant_name: Dari
 - slug: pashto
   code: ps
   normalized_code: ps

--- a/apis/microsoft.md
+++ b/apis/microsoft.md
@@ -467,7 +467,7 @@ supported_languages:
   normalized_code: fa-af
   base_code: fa
   name: Persian
-  variant_name: null
+  variant_name: Dari
 - slug: pashto
   code: ps
   normalized_code: ps

--- a/apis/systran.md
+++ b/apis/systran.md
@@ -210,7 +210,7 @@ supported_languages:
   normalized_code: fa-af
   base_code: fa
   name: Persian
-  variant_name: null
+  variant_name: Dari
 - slug: pashto
   code: ps
   normalized_code: ps

--- a/generate.py
+++ b/generate.py
@@ -78,6 +78,8 @@ def get_language_variant_name(locale_code, api_id):
   lang_code = parts[0]
   if lang_code == 'lzh':
     names.append('Literary') # Chinese
+  if lang_code == 'fa' and 'af' in parts:
+    names.append('Dari') # Persian
   for part in parts[1:]:
     if part in SCRIPTS:
       names.append(SCRIPTS[part])


### PR DESCRIPTION
- Clearly indicate Dari as a variant of Persian
- Lay groundwork for listing closely related languages
