### PR TITLE
Add Jekyll redirect plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'github-pages', group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.12'
+  gem 'jekyll-redirect-from'
   gem 'jekyll-target-blank'
   gem 'jekyll-seo-tag'
   gem 'html-proofer'

--- a/_config.yml
+++ b/_config.yml
@@ -156,6 +156,7 @@ ga_tracking: G-MJD8MHH513
 plugins:
   - jekyll-sitemap
   - jekyll-feed
+  - jekyll-redirect-from
   - jekyll-target-blank
   - jekyll-seo-tag
   - html-proofer


### PR DESCRIPTION
# Description

Add Jekyll redirect plugin - https://github.com/jekyll/jekyll-redirect-from

Then we can add urls for synonyms to pages.

## Type of PR

Meta

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
