### PR TITLE
Add redirects from alternative API paths

### DIFF
--- a/apis/alexa-ai.md
+++ b/apis/alexa-ai.md
@@ -76,6 +76,7 @@ integrations:
 - slug: phrase
   name: Phrase TMS
 nav_order: 990
+redirect_from: alexa-translations-a.i.
 
 ---
 

--- a/apis/alexa-ai.md
+++ b/apis/alexa-ai.md
@@ -76,7 +76,7 @@ integrations:
 - slug: phrase
   name: Phrase TMS
 nav_order: 990
-redirect_from: alexa-translations-a.i.
+redirect_from: alexa-translations-ai
 
 ---
 

--- a/apis/alibaba.md
+++ b/apis/alibaba.md
@@ -1297,6 +1297,7 @@ supported_languages:
   variant_name: null
 integrations: []
 nav_order: 786
+redirect_from: alibaba-translate
 
 ---
 

--- a/apis/amazon.md
+++ b/apis/amazon.md
@@ -488,6 +488,7 @@ integrations:
   name: XTM
   glossary: true
 nav_order: 925
+redirect_from: amazon-translate
 
 ---
 

--- a/apis/baidu.md
+++ b/apis/baidu.md
@@ -1222,6 +1222,7 @@ integrations:
 - slug: smartcat
   name: Smartcat
 nav_order: 799
+redirect_from: baidu-translate
 
 ---
 

--- a/apis/google.md
+++ b/apis/google.md
@@ -712,6 +712,7 @@ integrations:
   name: XTM
   custom: true
 nav_order: 891
+redirect_from: google-translate
 
 ---
 

--- a/apis/lingmo.md
+++ b/apis/lingmo.md
@@ -175,6 +175,7 @@ supported_languages:
   variant_name: Simplified Chinese
 integrations: []
 nav_order: 973
+redirect_from: lingmo-translation
 
 ---
 

--- a/apis/microsoft.md
+++ b/apis/microsoft.md
@@ -715,6 +715,7 @@ integrations:
   name: XTM
   custom: true
 nav_order: 889
+redirect_from: microsoft-translator
 
 ---
 

--- a/apis/mirai.md
+++ b/apis/mirai.md
@@ -103,6 +103,7 @@ integrations:
 - slug: phrase
   name: Phrase TMS
 nav_order: 986
+redirect_from: mirai-translate
 
 ---
 

--- a/apis/omniscien.md
+++ b/apis/omniscien.md
@@ -388,6 +388,7 @@ integrations:
   name: XTM
   custom: true
 nav_order: 939
+redirect_from: omniscien-technologies
 
 ---
 

--- a/apis/papago.md
+++ b/apis/papago.md
@@ -99,6 +99,7 @@ supported_languages:
   variant_name: Traditional Chinese
 integrations: []
 nav_order: 986
+redirect_from: papago-translation
 
 ---
 

--- a/apis/rozetta.md
+++ b/apis/rozetta.md
@@ -593,6 +593,7 @@ integrations:
   custom: true
   glossary: true
 nav_order: 904
+redirect_from: rozetta-t-400
 
 ---
 

--- a/apis/sap.md
+++ b/apis/sap.md
@@ -249,6 +249,7 @@ integrations:
 - slug: xtm
   name: XTM
 nav_order: 961
+redirect_from: sap-translation-hub
 
 ---
 

--- a/apis/sunda.md
+++ b/apis/sunda.md
@@ -27,6 +27,7 @@ supported_languages:
   variant_name: null
 integrations: []
 nav_order: 998
+redirect_from: sunda-translator
 
 ---
 

--- a/apis/tarjama.md
+++ b/apis/tarjama.md
@@ -25,6 +25,7 @@ supported_languages:
   variant_name: null
 integrations: []
 nav_order: 998
+redirect_from: tarjama-mt
 
 ---
 

--- a/apis/tencent.md
+++ b/apis/tencent.md
@@ -129,6 +129,7 @@ integrations:
 - slug: phrase
   name: Phrase TMS
 nav_order: 981
+redirect_from: tencent-machine-translation
 
 ---
 

--- a/apis/watson.md
+++ b/apis/watson.md
@@ -339,6 +339,7 @@ integrations:
   name: Smartling
   custom: true
 nav_order: 947
+redirect_from: watson-language-translator
 
 ---
 

--- a/apis/yandex.md
+++ b/apis/yandex.md
@@ -583,6 +583,7 @@ integrations:
 - slug: wordfast
   name: Wordfast
 nav_order: 907
+redirect_from: yandex-translate
 
 ---
 

--- a/apis/youdao.md
+++ b/apis/youdao.md
@@ -687,6 +687,7 @@ supported_languages:
   variant_name: null
 integrations: []
 nav_order: 888
+redirect_from: youdao-translate
 
 ---
 

--- a/generate.py
+++ b/generate.py
@@ -91,7 +91,7 @@ def get_language_variant_name(locale_code, api_id):
 
 def slugify(name):
   # Should work *exactly* like in Liquid!
-  return name.lower().replace(' ', '-')
+  return name.lower().replace(' ', '-').replace('.', '')
 
 def flatten(l):
   _ = []

--- a/generate.py
+++ b/generate.py
@@ -327,6 +327,10 @@ for api in APIS:
     'nav_order': 1000 - len(supported_languages)
   }
 
+  name_slug = slugify(name)
+  if name_slug != api_id:
+    frontmatter['redirect_from'] = name_slug
+
   content = read_content(filepath)
 
   filepath = f'apis/{ api_id }.md'


### PR DESCRIPTION
# Description

Let e.g. machinetranslate.org/google-translate redirect to machinetranslate.org/google

The only real code change is in generate.py.

## Type of PR

Meta

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
