### PR TITLE
Infoboxes overflow on mobile

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -30,6 +30,7 @@
     padding: 0.1em;
     padding-left: 2em;
     padding-right: 1em;
+    overflow-wrap: anywhere;
   }
 
 }


### PR DESCRIPTION
Blockquotes are overflowing on mobile, both links and spans with words separated by a comma and a space:

<img width="720" alt="Screenshot 2023-03-24 at 21 33 52" src="https://user-images.githubusercontent.com/11457984/227599254-c76f2d59-9956-412c-a2b0-82b34f9a17cc.png">

This will fix it.