### PR TITLE
Downgrade just-the-docs plugin version from 0.5.4 to 0.4.1

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -162,7 +162,7 @@ defaults:
         type: Article
 
 # Just the Docs
-remote_theme: pmarsceill/just-the-docs@v0.5.4
+remote_theme: pmarsceill/just-the-docs@v0.4.1
 logo: favicon.ico
 color_scheme: swissred
 search:


### PR DESCRIPTION
Test if 0.4.1 is faster than 0.5.4, else we may go back to 0.3.3.

0.5.4 took 37 minutes (vs 25) and also has some style issues that would need fixing.

0.4.1 because it has this fix: https://github.com/just-the-docs/just-the-docs/issues/863

# Description

Potentially partly addresses #489 

## Type of PR

- Meta / infra

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
