### PR TITLE
Use description as title for SEO

### DIFF
--- a/aggregators/crosslang.md
+++ b/aggregators/crosslang.md
@@ -1,7 +1,7 @@
 ---
 layout: aggregator
 title: Crosslang MT Gateway
-description: The Crosslang MT Gateway aggregator
+description: The Crosslang MT Gateway machine translation API aggregator
 id: crosslang
 parent: Aggregators
 urls:
@@ -20,6 +20,8 @@ supported_apis:
 - slug: systran
   name: SYSTRAN
 self-serve: false
+seo:
+  name: The Crosslang MT Gateway machine translation API aggregator
 
 ---
 

--- a/aggregators/custom-mt.md
+++ b/aggregators/custom-mt.md
@@ -1,7 +1,7 @@
 ---
 layout: aggregator
 title: Custom.MT
-description: The Custom.MT aggregator
+description: The Custom.MT machine translation API aggregator
 id: custom-mt
 parent: Aggregators
 urls:
@@ -24,6 +24,8 @@ supported_apis:
 - slug: xl8
   name: XL8
 self-serve: true
+seo:
+  name: The Custom.MT machine translation API aggregator
 
 ---
 

--- a/aggregators/human-science.md
+++ b/aggregators/human-science.md
@@ -1,7 +1,7 @@
 ---
 layout: aggregator
 title: Human Science
-description: The Human Science aggregator
+description: The Human Science machine translation API aggregator
 id: human-science
 parent: Aggregators
 urls:
@@ -13,6 +13,8 @@ supported_apis:
 - slug: microsoft
   name: Microsoft Translator
 self-serve: false
+seo:
+  name: The Human Science machine translation API aggregator
 
 ---
 

--- a/aggregators/intento.md
+++ b/aggregators/intento.md
@@ -1,7 +1,7 @@
 ---
 layout: aggregator
 title: Intento
-description: The Intento aggregator
+description: The Intento machine translation API aggregator
 id: intento
 parent: Aggregators
 urls:
@@ -42,6 +42,8 @@ supported_apis:
 - slug: youdao
   name: Youdao Translate
 self-serve: true
+seo:
+  name: The Intento machine translation API aggregator
 
 ---
 

--- a/aggregators/tmxmall.md
+++ b/aggregators/tmxmall.md
@@ -1,7 +1,7 @@
 ---
 layout: aggregator
 title: TMXmall
-description: The TMXmall aggregator
+description: The TMXmall machine translation API aggregator
 id: tmxmall
 parent: Aggregators
 urls:
@@ -30,6 +30,8 @@ supported_apis:
 - slug: youdao
   name: Youdao Translate
 self-serve: false
+seo:
+  name: The TMXmall machine translation API aggregator
 
 ---
 

--- a/apis/aisa.md
+++ b/apis/aisa.md
@@ -138,6 +138,8 @@ integrations:
   active: false
 nav_order: 980
 active: true
+seo:
+  name: The AISA machine translation API
 
 ---
 

--- a/apis/alexa-translations-ai.md
+++ b/apis/alexa-translations-ai.md
@@ -97,6 +97,8 @@ integrations:
   - https://appstore.rws.com/plugin/149/
 nav_order: 988
 active: true
+seo:
+  name: The Alexa Translations A.I. machine translation API
 
 ---
 

--- a/apis/alibaba.md
+++ b/apis/alibaba.md
@@ -1304,6 +1304,8 @@ integrations:
   - https://store.crowdin.com/alibaba
 nav_order: 786
 active: true
+seo:
+  name: The Alibaba Translate machine translation API
 redirect_from: alibaba-translate
 
 ---

--- a/apis/amazon.md
+++ b/apis/amazon.md
@@ -505,6 +505,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-amazon-translate-mt-engine.html
 nav_order: 925
 active: true
+seo:
+  name: The Amazon Translate machine translation API
 redirect_from: amazon-translate
 
 ---

--- a/apis/amplexor-mt.md
+++ b/apis/amplexor-mt.md
@@ -19,6 +19,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-acolad-mt-engine.html
 nav_order: 1000
 active: true
+seo:
+  name: The Amplexor MT machine translation API
 
 ---
 

--- a/apis/apertium.md
+++ b/apis/apertium.md
@@ -297,6 +297,8 @@ integrations:
   name: OmegaT
 nav_order: 954
 active: true
+seo:
+  name: The Apertium machine translation API
 
 ---
 

--- a/apis/apptek.md
+++ b/apis/apptek.md
@@ -456,6 +456,8 @@ integrations:
   name: GlobalLink
 nav_order: 927
 active: true
+seo:
+  name: The AppTek machine translation API
 
 ---
 

--- a/apis/baidu.md
+++ b/apis/baidu.md
@@ -1229,6 +1229,8 @@ integrations:
   active: false
 nav_order: 799
 active: true
+seo:
+  name: The Baidu Translate machine translation API
 redirect_from: baidu-translate
 
 ---

--- a/apis/belazar.md
+++ b/apis/belazar.md
@@ -28,6 +28,8 @@ integrations:
   name: OmegaT
 nav_order: 998
 active: true
+seo:
+  name: The Belazar machine translation API
 
 ---
 

--- a/apis/cloudtranslation.md
+++ b/apis/cloudtranslation.md
@@ -63,6 +63,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 992
 active: true
+seo:
+  name: The CloudTranslation machine translation API
 
 ---
 

--- a/apis/deepl.md
+++ b/apis/deepl.md
@@ -289,6 +289,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-deepl-translator-mt-engine.html
 nav_order: 966
 active: true
+seo:
+  name: The DeepL machine translation API
 
 ---
 

--- a/apis/elia.md
+++ b/apis/elia.md
@@ -56,6 +56,8 @@ integrations:
   - https://appstore.rws.com/Plugins/154
 nav_order: 994
 active: true
+seo:
+  name: The Elia machine translation API
 
 ---
 

--- a/apis/etranslation.md
+++ b/apis/etranslation.md
@@ -210,6 +210,8 @@ integrations:
   - https://docs.memoq.com/current/en/Places/etranslation-mt-plugin-settings.html
 nav_order: 968
 active: true
+seo:
+  name: The eTranslation machine translation API
 
 ---
 

--- a/apis/fairtrade.md
+++ b/apis/fairtrade.md
@@ -16,6 +16,8 @@ integrations:
   name: Phrase TMS
 nav_order: 1000
 active: false
+seo:
+  name: The Fairtrade machine translation API
 
 ---
 

--- a/apis/geofluent.md
+++ b/apis/geofluent.md
@@ -20,6 +20,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-lionbridge-geofluent-mt-engine.html
 nav_order: 1000
 active: true
+seo:
+  name: The Geofluent machine translation API
 
 ---
 

--- a/apis/globalese.md
+++ b/apis/globalese.md
@@ -265,6 +265,8 @@ integrations:
   - https://globalese.atlassian.net/wiki/spaces/DOCS/pages/647037255
 nav_order: 966
 active: true
+seo:
+  name: The Globalese machine translation API
 
 ---
 

--- a/apis/google.md
+++ b/apis/google.md
@@ -897,6 +897,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-google-translate-mt-engine.html
 nav_order: 866
 active: true
+seo:
+  name: The Google Translate machine translation API
 redirect_from: google-translate
 
 ---

--- a/apis/iconic.md
+++ b/apis/iconic.md
@@ -366,6 +366,8 @@ integrations:
   active: false
 nav_order: 946
 active: false
+seo:
+  name: The Iconic machine translation API
 
 ---
 

--- a/apis/iptranslator.md
+++ b/apis/iptranslator.md
@@ -347,6 +347,8 @@ integrations:
   - https://docs.memoq.com/current/en/Places/iptranslator-plugin-settings.html
 nav_order: 946
 active: false
+seo:
+  name: The IP Translator machine translation API
 redirect_from: ip-translator
 
 ---

--- a/apis/judicio.md
+++ b/apis/judicio.md
@@ -38,6 +38,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 996
 active: true
+seo:
+  name: The Judicio machine translation API
 
 ---
 

--- a/apis/kakao.md
+++ b/apis/kakao.md
@@ -130,6 +130,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 981
 active: true
+seo:
+  name: The Kakao machine translation API
 
 ---
 

--- a/apis/kantanmt.md
+++ b/apis/kantanmt.md
@@ -382,6 +382,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-kantanmt-engine.html
 nav_order: 947
 active: true
+seo:
+  name: The KantanMT machine translation API
 
 ---
 

--- a/apis/kodensha.md
+++ b/apis/kodensha.md
@@ -269,6 +269,8 @@ integrations:
   active: false
 nav_order: 958
 active: true
+seo:
+  name: The Kodensha MT machine translation API
 redirect_from: kodensha-mt
 
 ---

--- a/apis/language-weaver.md
+++ b/apis/language-weaver.md
@@ -412,6 +412,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-language-weaver-mt-engine.html
 nav_order: 938
 active: true
+seo:
+  name: The Language Weaver machine translation API
 
 ---
 

--- a/apis/language-wire.md
+++ b/apis/language-wire.md
@@ -69,6 +69,8 @@ integrations:
   - https://www.languagewire.com/en/about-us/freelancers/guides-for-language-experts/trados-plugin
 nav_order: 992
 active: true
+seo:
+  name: The Language Wire machine translation API
 
 ---
 

--- a/apis/lilt.md
+++ b/apis/lilt.md
@@ -469,6 +469,8 @@ integrations:
   - https://support.lilt.com/kb/introduction-to-lilt-translate
 nav_order: 926
 active: true
+seo:
+  name: The Lilt machine translation API
 
 ---
 

--- a/apis/lingmo.md
+++ b/apis/lingmo.md
@@ -177,6 +177,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 973
 active: true
+seo:
+  name: The Lingmo Translation machine translation API
 redirect_from: lingmo-translation
 
 ---

--- a/apis/lingo24.md
+++ b/apis/lingo24.md
@@ -104,6 +104,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-lingo24-mt-engine.html
 nav_order: 986
 active: false
+seo:
+  name: The Lingo24 machine translation API
 
 ---
 

--- a/apis/lingua-custodia.md
+++ b/apis/lingua-custodia.md
@@ -18,6 +18,8 @@ integrations:
   - https://wordbee.atlassian.net/wiki/spaces/WBT/pages/711232/Machine+Translation+Settings
 nav_order: 1000
 active: true
+seo:
+  name: The Lingua Custodia machine translation API
 
 ---
 

--- a/apis/lingvanex.md
+++ b/apis/lingvanex.md
@@ -669,6 +669,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 891
 active: true
+seo:
+  name: The LingvaNex machine translation API
 
 ---
 

--- a/apis/ltgear.md
+++ b/apis/ltgear.md
@@ -20,6 +20,8 @@ integrations:
   - https://appstore.rws.com/Plugins/178
 nav_order: 1000
 active: true
+seo:
+  name: The LT Gear machine translation API
 redirect_from: lt-gear
 
 ---

--- a/apis/lucy.md
+++ b/apis/lucy.md
@@ -78,6 +78,8 @@ integrations:
   - https://confluence.translate5.net/display/BUS/Lucy
 nav_order: 991
 active: false
+seo:
+  name: The Lucy machine translation API
 
 ---
 

--- a/apis/microsoft.md
+++ b/apis/microsoft.md
@@ -750,6 +750,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-microsoft-translator-mt-engine.html
 nav_order: 889
 active: true
+seo:
+  name: The Microsoft Translator machine translation API
 redirect_from: microsoft-translator
 
 ---

--- a/apis/mirai.md
+++ b/apis/mirai.md
@@ -111,6 +111,8 @@ integrations:
   active: false
 nav_order: 986
 active: true
+seo:
+  name: The Mirai Translator machine translation API
 redirect_from: mirai-translator
 
 ---

--- a/apis/modernmt.md
+++ b/apis/modernmt.md
@@ -1246,6 +1246,8 @@ integrations:
   - https://www.wordfast.net/wiki/Connecting_Wordfast_Pro_to_Modern_MT
 nav_order: 800
 active: true
+seo:
+  name: The ModernMT machine translation API
 
 ---
 

--- a/apis/moraviamt.md
+++ b/apis/moraviamt.md
@@ -16,6 +16,8 @@ integrations:
   active: false
 nav_order: 1000
 active: true
+seo:
+  name: The MoraviaMT machine translation API
 
 ---
 

--- a/apis/moses.md
+++ b/apis/moses.md
@@ -26,6 +26,8 @@ integrations:
   - https://confluence.translate5.net/display/BUS/Moses
 nav_order: 1000
 active: true
+seo:
+  name: The Moses machine translation API
 
 ---
 

--- a/apis/niutrans.md
+++ b/apis/niutrans.md
@@ -2328,6 +2328,8 @@ integrations:
   active: false
 nav_order: 616
 active: true
+seo:
+  name: The Niutrans machine translation API
 
 ---
 

--- a/apis/npatmt.md
+++ b/apis/npatmt.md
@@ -19,6 +19,8 @@ integrations:
   - https://www.npat.co.jp/EXPRESS_price_list/EXPRESS_price_list.html
 nav_order: 1000
 active: true
+seo:
+  name: The NpatMT machine translation API
 
 ---
 

--- a/apis/octavemt.md
+++ b/apis/octavemt.md
@@ -16,6 +16,8 @@ integrations:
   name: Across
 nav_order: 1000
 active: true
+seo:
+  name: The OctaveMT machine translation API
 
 ---
 

--- a/apis/omniscien.md
+++ b/apis/omniscien.md
@@ -400,6 +400,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-omniscien-technologies-language-studio-mt-engine.html
 nav_order: 939
 active: true
+seo:
+  name: The Omniscien Technologies machine translation API
 redirect_from: omniscien-technologies
 
 ---

--- a/apis/opus-cat.md
+++ b/apis/opus-cat.md
@@ -26,6 +26,8 @@ integrations:
   - https://appstore.rws.com/Plugins/11
 nav_order: 1000
 active: true
+seo:
+  name: The Opus CAT machine translation API
 
 ---
 

--- a/apis/pangeamt.md
+++ b/apis/pangeamt.md
@@ -88,6 +88,8 @@ integrations:
   - https://confluence.translate5.net/display/CON/PangeaMT
 nav_order: 991
 active: true
+seo:
+  name: The PangeaMT machine translation API
 
 ---
 

--- a/apis/papago.md
+++ b/apis/papago.md
@@ -101,6 +101,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 986
 active: true
+seo:
+  name: The Papago Translation machine translation API
 redirect_from: papago-translation
 
 ---

--- a/apis/phrase-nextmt.md
+++ b/apis/phrase-nextmt.md
@@ -73,6 +73,8 @@ integrations:
   glossary: true
 nav_order: 991
 active: true
+seo:
+  name: The Phrase NextMT machine translation API
 
 ---
 

--- a/apis/plata-vicomtech.md
+++ b/apis/plata-vicomtech.md
@@ -17,6 +17,8 @@ integrations:
   - https://wordbee.atlassian.net/wiki/spaces/WBT/pages/711232/Machine+Translation+Settings
 nav_order: 1000
 active: false
+seo:
+  name: The Plata Vicomtech machine translation API
 
 ---
 

--- a/apis/promt.md
+++ b/apis/promt.md
@@ -272,6 +272,8 @@ integrations:
   name: Smartling
 nav_order: 959
 active: true
+seo:
+  name: The PROMT machine translation API
 
 ---
 

--- a/apis/reverso.md
+++ b/apis/reverso.md
@@ -174,6 +174,8 @@ integrations:
   - https://wordbee.atlassian.net/wiki/spaces/WBT/pages/711232/Machine+Translation+Settings
 nav_order: 974
 active: true
+seo:
+  name: The Reverso machine translation API
 
 ---
 

--- a/apis/rozetta.md
+++ b/apis/rozetta.md
@@ -601,6 +601,8 @@ integrations:
   - https://appstore.rws.com/plugin/187/
 nav_order: 904
 active: true
+seo:
+  name: The Rozetta T-400 machine translation API
 redirect_from: rozetta-t-400
 
 ---

--- a/apis/safaba.md
+++ b/apis/safaba.md
@@ -13,6 +13,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 1000
 active: false
+seo:
+  name: The Safaba machine translation API
 
 ---
 

--- a/apis/sap.md
+++ b/apis/sap.md
@@ -260,6 +260,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-sap-translation-hub-mt-engine.html
 nav_order: 960
 active: true
+seo:
+  name: The SAP Translation Hub machine translation API
 redirect_from: sap-translation-hub
 
 ---

--- a/apis/skrivanek.md
+++ b/apis/skrivanek.md
@@ -17,6 +17,8 @@ integrations:
   active: false
 nav_order: 1000
 active: true
+seo:
+  name: The Skrivanek machine translation API
 
 ---
 

--- a/apis/slate.md
+++ b/apis/slate.md
@@ -20,6 +20,8 @@ integrations:
   - https://docs.memoq.com/current/en/Places/slate-desktop-plugin-settings.html
 nav_order: 1000
 active: false
+seo:
+  name: The Slate Desktop machine translation API
 redirect_from: slate-desktop
 
 ---

--- a/apis/sogou-translate.md
+++ b/apis/sogou-translate.md
@@ -144,6 +144,8 @@ integrations:
   active: false
 nav_order: 979
 active: true
+seo:
+  name: The Sogou Translate machine translation API
 
 ---
 

--- a/apis/sunda.md
+++ b/apis/sunda.md
@@ -29,6 +29,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 998
 active: true
+seo:
+  name: The Sunda Translator machine translation API
 redirect_from: sunda-translator
 
 ---

--- a/apis/systran.md
+++ b/apis/systran.md
@@ -382,6 +382,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-systran-pure-neural-mt-engine.html
 nav_order: 946
 active: true
+seo:
+  name: The SYSTRAN machine translation API
 
 ---
 

--- a/apis/t-tact-an-zin.md
+++ b/apis/t-tact-an-zin.md
@@ -106,6 +106,8 @@ integrations:
   name: Phrase TMS
 nav_order: 985
 active: true
+seo:
+  name: The T-tact-AN-ZIN machine translation API
 
 ---
 

--- a/apis/tapta.md
+++ b/apis/tapta.md
@@ -55,6 +55,8 @@ integrations:
   url: https://docs.rws.com/785465/786629/sdl-multitrans/configuring-tapta
 nav_order: 994
 active: true
+seo:
+  name: The TAPTA machine translation API
 
 ---
 

--- a/apis/tarjama.md
+++ b/apis/tarjama.md
@@ -27,6 +27,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 998
 active: true
+seo:
+  name: The Tarjama MT machine translation API
 redirect_from: tarjama-mt
 
 ---

--- a/apis/tauyou.md
+++ b/apis/tauyou.md
@@ -29,6 +29,8 @@ integrations:
   - https://help.xtm.cloud/en/xtm-cloud/13.2/en/connecting-xtm-to-your-tauyou-mt-engine.html
 nav_order: 1000
 active: false
+seo:
+  name: The Tauyou machine translation API
 
 ---
 

--- a/apis/tencent.md
+++ b/apis/tencent.md
@@ -141,6 +141,8 @@ integrations:
   - https://github.com/yoyicue/omegat-tencent-plugin
 nav_order: 981
 active: true
+seo:
+  name: The Tencent Machine Translation machine translation API
 redirect_from: tencent-machine-translation
 
 ---

--- a/apis/textra.md
+++ b/apis/textra.md
@@ -225,6 +225,8 @@ integrations:
   - https://mt-auto-minhon-mlt.ucri.jgn-x.jp/tool/xtm/edit/
 nav_order: 968
 active: true
+seo:
+  name: The TexTra machine translation API
 
 ---
 

--- a/apis/textshuttle.md
+++ b/apis/textshuttle.md
@@ -162,6 +162,8 @@ integrations:
   - https://wordbee.atlassian.net/wiki/spaces/WBT/pages/711232/Machine+Translation+Settings
 nav_order: 979
 active: true
+seo:
+  name: The TextShuttle machine translation API
 
 ---
 

--- a/apis/tilde.md
+++ b/apis/tilde.md
@@ -173,6 +173,8 @@ integrations:
   - https://wordbee.atlassian.net/wiki/spaces/WBT/pages/711232/Machine+Translation+Settings
 nav_order: 978
 active: true
+seo:
+  name: The Tilde machine translation API
 
 ---
 

--- a/apis/translateme.md
+++ b/apis/translateme.md
@@ -81,6 +81,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 989
 active: true
+seo:
+  name: The TranslateMe machine translation API
 
 ---
 

--- a/apis/transperfect-nmt.md
+++ b/apis/transperfect-nmt.md
@@ -16,6 +16,8 @@ integrations:
   name: GlobalLink
 nav_order: 1000
 active: true
+seo:
+  name: The TransPerfect NMT machine translation API
 
 ---
 

--- a/apis/trebe.md
+++ b/apis/trebe.md
@@ -56,6 +56,8 @@ integrations:
   - https://appstore.rws.com/Plugin/195
 nav_order: 994
 active: true
+seo:
+  name: The Trebe machine translation API
 
 ---
 

--- a/apis/ubiqus.md
+++ b/apis/ubiqus.md
@@ -23,6 +23,8 @@ integrations:
   active: false
 nav_order: 1000
 active: true
+seo:
+  name: The Ubiqus NMT machine translation API
 redirect_from: ubiqus-nmt
 
 ---

--- a/apis/unbabel.md
+++ b/apis/unbabel.md
@@ -207,6 +207,8 @@ more_languages_by_request: true
 integrations: []
 nav_order: 968
 active: true
+seo:
+  name: The Unbabel machine translation API
 
 ---
 

--- a/apis/watson.md
+++ b/apis/watson.md
@@ -374,6 +374,8 @@ integrations:
   custom: true
 nav_order: 942
 active: true
+seo:
+  name: The Watson Language Translator machine translation API
 redirect_from: watson-language-translator
 
 ---

--- a/apis/wordlingo.md
+++ b/apis/wordlingo.md
@@ -415,6 +415,8 @@ integrations:
   - https://www.wordfast.com/WFP/4.5/c1060284.html
 nav_order: 934
 active: true
+seo:
+  name: The Wordlingo machine translation API
 
 ---
 

--- a/apis/xl8.md
+++ b/apis/xl8.md
@@ -304,6 +304,8 @@ integrations:
   - https://s3.amazonaws.com/static.xl8.ai/doc/XL8+Skroll+SDL+Plugin.pdf
 nav_order: 954
 active: true
+seo:
+  name: The XL8 machine translation API
 
 ---
 

--- a/apis/yandex.md
+++ b/apis/yandex.md
@@ -586,6 +586,8 @@ integrations:
   name: Wordfast
 nav_order: 907
 active: true
+seo:
+  name: The Yandex Translate machine translation API
 redirect_from: yandex-translate
 
 ---

--- a/apis/yeekit.md
+++ b/apis/yeekit.md
@@ -27,6 +27,8 @@ more_languages_by_request: false
 integrations: []
 nav_order: 998
 active: true
+seo:
+  name: The YeeKit machine translation API
 
 ---
 

--- a/apis/youdao.md
+++ b/apis/youdao.md
@@ -693,6 +693,8 @@ integrations:
   active: false
 nav_order: 888
 active: true
+seo:
+  name: The Youdao Translate machine translation API
 redirect_from: youdao-translate
 
 ---

--- a/generate.py
+++ b/generate.py
@@ -167,7 +167,7 @@ for code in LANGUAGE_FAMILIES:
     'title': name,
     'description': desc,
     'code': code,
-    'languages': languages
+    'languages': languages,
     'seo': {
       'name': desc
     }

--- a/generate.py
+++ b/generate.py
@@ -158,14 +158,19 @@ for code in LANGUAGE_FAMILIES:
       })
   languages.sort(key=lambda language: language['name'])
 
+  desc = f'Machine translation for the { name } language family'
+
   frontmatter = {
     'nav_exclude': True,
     'parent': 'Language families',
     'layout': 'language_family',
     'title': name,
-    'description': f'Machine translation for the { name } language family',
+    'description': desc,
     'code': code,
     'languages': languages
+    'seo': {
+      'name': desc
+    }
   }
 
   with open(filepath, 'w', encoding='utf8') as f:
@@ -209,15 +214,20 @@ for language in LANGUAGES:
 
   supported_apis.sort(key=lambda api: api['supported_language_count'])
 
+  desc = f'Machine translation for { name }'
+
   frontmatter = {
     'nav_order': 1000 - len(supported_apis),
     'parent': 'Languages',
     'layout': 'language',
     'title': name,
-    'description': f'Machine translation for { name }',
+    'description': desc,
     **language,
     'family': family,
     'supported_apis': supported_apis,
+    'seo': {
+      'name': desc
+    }
   }
 
   slug = slugify(name)
@@ -321,10 +331,12 @@ for api in APIS:
             **i[api_id]
           })
 
+  desc = f'The { name } machine translation API'
+
   frontmatter = {
     'layout': 'api',
     'title': name,
-    'description': f'The { name } machine translation API',
+    'description': desc,
     'id': api_id,
     'parent': 'APIs',
     'urls': urls,
@@ -336,6 +348,9 @@ for api in APIS:
     'integrations': integrations,
     'nav_order': 1000 - len(supported_languages),
     'active': api.get('active', True),
+    'seo': {
+      'name': desc
+    }
   }
 
   name_slug = slugify(name)
@@ -404,10 +419,12 @@ for tms in INTEGRATIONS:
     else:
       raise 'TMS type must include `tms` or `cat`.'
 
+    desc = f'Machine translation API integrations in { tms_name }'
+
     frontmatter = {
         'layout': 'integration',
         'title':  tms_name,
-        'description': f'Machine translation API integrations in { tms_name }',
+        'description': desc,
         'id': tms_id,
         'parent': 'Integrations',
         'type': tms_type,
@@ -417,6 +434,9 @@ for tms in INTEGRATIONS:
         'fuzzy_repair': fuzzy_repair,
         'open-source': tms_open_source,
         'quality_estimation_api_integrations': tms_quality_estimation_api_integrations,
+        'seo': {
+          'name': desc
+        }
     }
 
     content = read_content(filepath)
@@ -459,15 +479,20 @@ for a in AGGREGATORS:
       except KeyError:
         pass
 
+    desc = f'The { a_name } machine translation API aggregator'
+
     frontmatter = {
         'layout': 'aggregator',
         'title': a_name,
-        'description': f'The { a_name } aggregator',
+        'description': desc,
         'id': a_id,
         'parent': 'Aggregators',
         'urls': a_urls,
         'supported_apis': a_supported_apis,
         'self-serve': a_self_serve,
+        'seo': {
+          'name': desc
+        }
     }
     
     content = read_content(filepath)

--- a/integrations/across.md
+++ b/integrations/across.md
@@ -30,6 +30,8 @@ api_integrations:
 fuzzy_repair: true
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Across
 
 ---
 

--- a/integrations/crowdin.md
+++ b/integrations/crowdin.md
@@ -85,6 +85,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Crowdin
 
 ---
 

--- a/integrations/eluna.md
+++ b/integrations/eluna.md
@@ -19,6 +19,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in eLUNa
 
 ---
 

--- a/integrations/globallink.md
+++ b/integrations/globallink.md
@@ -33,6 +33,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in GlobalLink
 
 ---
 

--- a/integrations/lilt.md
+++ b/integrations/lilt.md
@@ -19,6 +19,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Lilt
 
 ---
 

--- a/integrations/matecat.md
+++ b/integrations/matecat.md
@@ -50,6 +50,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in MateCat
 
 ---
 

--- a/integrations/memoq.md
+++ b/integrations/memoq.md
@@ -134,6 +134,8 @@ api_integrations:
 fuzzy_repair: true
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in MemoQ
 
 ---
 

--- a/integrations/multitrans.md
+++ b/integrations/multitrans.md
@@ -38,6 +38,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Multitrans
 
 ---
 

--- a/integrations/omegat.md
+++ b/integrations/omegat.md
@@ -37,6 +37,8 @@ api_integrations:
 fuzzy_repair: true
 open-source: true
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in OmegaT
 
 ---
 

--- a/integrations/passolo.md
+++ b/integrations/passolo.md
@@ -26,6 +26,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Passolo
 
 ---
 

--- a/integrations/phrase.md
+++ b/integrations/phrase.md
@@ -101,6 +101,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Phrase TMS
 
 ---
 

--- a/integrations/smartcat.md
+++ b/integrations/smartcat.md
@@ -51,6 +51,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Smartcat
 
 ---
 

--- a/integrations/smartling.md
+++ b/integrations/smartling.md
@@ -39,6 +39,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Smartling
 
 ---
 

--- a/integrations/tolgee.md
+++ b/integrations/tolgee.md
@@ -24,6 +24,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: true
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Tolgee
 
 ---
 

--- a/integrations/trados.md
+++ b/integrations/trados.md
@@ -178,6 +178,8 @@ api_integrations:
 fuzzy_repair: true
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Trados Studio
 
 ---
 

--- a/integrations/transifex.md
+++ b/integrations/transifex.md
@@ -31,6 +31,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Transifex
 
 ---
 

--- a/integrations/transitnxt.md
+++ b/integrations/transitnxt.md
@@ -31,6 +31,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in TransitNXT
 
 ---
 

--- a/integrations/translate5.md
+++ b/integrations/translate5.md
@@ -44,6 +44,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: true
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in translate5
 
 ---
 

--- a/integrations/wordbee.md
+++ b/integrations/wordbee.md
@@ -67,6 +67,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Wordbee
 
 ---
 

--- a/integrations/wordfast.md
+++ b/integrations/wordfast.md
@@ -55,6 +55,8 @@ api_integrations:
 fuzzy_repair: false
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in Wordfast
 
 ---
 

--- a/integrations/xtm.md
+++ b/integrations/xtm.md
@@ -111,6 +111,8 @@ api_integrations:
 fuzzy_repair: true
 open-source: false
 quality_estimation_api_integrations: null
+seo:
+  name: Machine translation API integrations in XTM
 
 ---
 

--- a/languages/abkhaz.md
+++ b/languages/abkhaz.md
@@ -28,6 +28,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Abkhaz
 
 ---
 

--- a/languages/acehnese.md
+++ b/languages/acehnese.md
@@ -31,6 +31,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Acehnese
 
 ---
 

--- a/languages/acholi.md
+++ b/languages/acholi.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Acholi
 
 ---
 

--- a/languages/afrikaans.md
+++ b/languages/afrikaans.md
@@ -82,6 +82,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Afrikaans
 
 ---
 

--- a/languages/afro-asiatic.md
+++ b/languages/afro-asiatic.md
@@ -30,6 +30,8 @@ languages:
   name: Tamasheq
 - slug: tigrinya
   name: Tigrinya
+seo:
+  name: Machine translation for the Afro-Asiatic language family
 
 ---
 

--- a/languages/akan.md
+++ b/languages/akan.md
@@ -36,6 +36,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Akan
 
 ---
 

--- a/languages/albanian.md
+++ b/languages/albanian.md
@@ -83,6 +83,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Albanian
 
 ---
 

--- a/languages/alemannic.md
+++ b/languages/alemannic.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: textshuttle
   name: TextShuttle
   supported_language_count: 21
+seo:
+  name: Machine translation for Alemannic
 
 ---
 

--- a/languages/algerian-arabic.md
+++ b/languages/algerian-arabic.md
@@ -32,6 +32,8 @@ supported_apis:
 - id: baidu
   name: Baidu Translate
   supported_language_count: 197
+seo:
+  name: Machine translation for Algerian Arabic
 
 ---
 

--- a/languages/amharic.md
+++ b/languages/amharic.md
@@ -64,6 +64,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Amharic
 
 ---
 

--- a/languages/arabic.md
+++ b/languages/arabic.md
@@ -170,6 +170,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Arabic
 
 ---
 

--- a/languages/aragonese.md
+++ b/languages/aragonese.md
@@ -34,6 +34,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Aragonese
 
 ---
 

--- a/languages/armenian.md
+++ b/languages/armenian.md
@@ -75,6 +75,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Armenian
 
 ---
 

--- a/languages/arpitan.md
+++ b/languages/arpitan.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: apertium
   name: Apertium
   supported_language_count: 46
+seo:
+  name: Machine translation for Arpitan
 
 ---
 

--- a/languages/assamese.md
+++ b/languages/assamese.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Assamese
 
 ---
 

--- a/languages/asturian.md
+++ b/languages/asturian.md
@@ -36,6 +36,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Asturian
 
 ---
 

--- a/languages/austroasiatic.md
+++ b/languages/austroasiatic.md
@@ -12,6 +12,8 @@ languages:
   name: Marshallese
 - slug: vietnamese
   name: Vietnamese
+seo:
+  name: Machine translation for the Austroasiatic language family
 
 ---
 

--- a/languages/austronesian.md
+++ b/languages/austronesian.md
@@ -56,6 +56,8 @@ languages:
   name: Tonga
 - slug: waray
   name: Waray
+seo:
+  name: Machine translation for the Austronesian language family
 
 ---
 

--- a/languages/awadhi.md
+++ b/languages/awadhi.md
@@ -30,6 +30,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Awadhi
 
 ---
 

--- a/languages/ayacucho.md
+++ b/languages/ayacucho.md
@@ -28,6 +28,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Ayacucho
 
 ---
 

--- a/languages/aymara.md
+++ b/languages/aymara.md
@@ -37,6 +37,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Aymara
 
 ---
 

--- a/languages/aymaran.md
+++ b/languages/aymaran.md
@@ -8,6 +8,8 @@ code: aym
 languages:
 - slug: aymara
   name: Aymara
+seo:
+  name: Machine translation for the Aymaran language family
 
 ---
 

--- a/languages/azerbaijani.md
+++ b/languages/azerbaijani.md
@@ -84,6 +84,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Azerbaijani
 
 ---
 

--- a/languages/balinese.md
+++ b/languages/balinese.md
@@ -24,6 +24,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Balinese
 
 ---
 

--- a/languages/balochi.md
+++ b/languages/balochi.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Balochi
 
 ---
 

--- a/languages/baltic.md
+++ b/languages/baltic.md
@@ -12,6 +12,8 @@ languages:
   name: Latvian
 - slug: lithuanian
   name: Lithuanian
+seo:
+  name: Machine translation for the Baltic language family
 
 ---
 

--- a/languages/bambara.md
+++ b/languages/bambara.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Bambara
 
 ---
 

--- a/languages/banjar.md
+++ b/languages/banjar.md
@@ -25,6 +25,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Banjar
 
 ---
 

--- a/languages/bantu.md
+++ b/languages/bantu.md
@@ -50,6 +50,8 @@ languages:
   name: Xhosa
 - slug: zulu
   name: Zulu
+seo:
+  name: Machine translation for the Bantu language family
 
 ---
 

--- a/languages/bashkir.md
+++ b/languages/bashkir.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Bashkir
 
 ---
 

--- a/languages/basque.md
+++ b/languages/basque.md
@@ -70,6 +70,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Basque
 
 ---
 

--- a/languages/belarusian.md
+++ b/languages/belarusian.md
@@ -72,6 +72,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Belarusian
 
 ---
 

--- a/languages/bemba.md
+++ b/languages/bemba.md
@@ -42,6 +42,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Bemba
 
 ---
 

--- a/languages/bengali.md
+++ b/languages/bengali.md
@@ -85,6 +85,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Bengali
 
 ---
 

--- a/languages/berber.md
+++ b/languages/berber.md
@@ -36,6 +36,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Berber
 
 ---
 

--- a/languages/bhojpuri.md
+++ b/languages/bhojpuri.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Bhojpuri
 
 ---
 

--- a/languages/bislama.md
+++ b/languages/bislama.md
@@ -32,6 +32,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Bislama
 
 ---
 

--- a/languages/bosnian.md
+++ b/languages/bosnian.md
@@ -82,6 +82,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Bosnian
 
 ---
 

--- a/languages/breton.md
+++ b/languages/breton.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Breton
 
 ---
 

--- a/languages/buginese.md
+++ b/languages/buginese.md
@@ -25,6 +25,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Buginese
 
 ---
 

--- a/languages/bulgarian.md
+++ b/languages/bulgarian.md
@@ -117,6 +117,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Bulgarian
 
 ---
 

--- a/languages/burmese.md
+++ b/languages/burmese.md
@@ -72,6 +72,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Burmese
 
 ---
 ## Character encoding

--- a/languages/cantonese.md
+++ b/languages/cantonese.md
@@ -48,6 +48,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Cantonese
 
 ---
 

--- a/languages/cape-verdean-creole.md
+++ b/languages/cape-verdean-creole.md
@@ -27,6 +27,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Cape Verdean Creole
 
 ---
 

--- a/languages/catalan.md
+++ b/languages/catalan.md
@@ -104,6 +104,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Catalan
 
 ---
 

--- a/languages/cebuano.md
+++ b/languages/cebuano.md
@@ -50,6 +50,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Cebuano
 
 ---
 

--- a/languages/celtic.md
+++ b/languages/celtic.md
@@ -18,6 +18,8 @@ languages:
   name: Scottish Gaelic
 - slug: welsh
   name: Welsh
+seo:
+  name: Machine translation for the Celtic language family
 
 ---
 

--- a/languages/central-atlas-tamazight.md
+++ b/languages/central-atlas-tamazight.md
@@ -27,6 +27,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Central Atlas Tamazight
 
 ---
 

--- a/languages/chadic.md
+++ b/languages/chadic.md
@@ -8,6 +8,8 @@ code: cdc
 languages:
 - slug: hausa
   name: Hausa
+seo:
+  name: Machine translation for the Chadic language family
 
 ---
 

--- a/languages/cherokee.md
+++ b/languages/cherokee.md
@@ -32,6 +32,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Cherokee
 
 ---
 

--- a/languages/chhattisgarhi.md
+++ b/languages/chhattisgarhi.md
@@ -30,6 +30,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Chhattisgarhi
 
 ---
 

--- a/languages/chichewa.md
+++ b/languages/chichewa.md
@@ -46,6 +46,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Chichewa
 
 ---
 

--- a/languages/chinese.md
+++ b/languages/chinese.md
@@ -180,6 +180,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Chinese
 
 ---
 

--- a/languages/chokwe.md
+++ b/languages/chokwe.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Chokwe
 
 ---
 

--- a/languages/chuvash.md
+++ b/languages/chuvash.md
@@ -31,6 +31,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Chuvash
 
 ---
 

--- a/languages/cornish.md
+++ b/languages/cornish.md
@@ -30,6 +30,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Cornish
 
 ---
 

--- a/languages/corsican.md
+++ b/languages/corsican.md
@@ -43,6 +43,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Corsican
 
 ---
 

--- a/languages/creoles.md
+++ b/languages/creoles.md
@@ -8,6 +8,8 @@ code: crp
 languages:
 - slug: sango
   name: Sango
+seo:
+  name: Machine translation for the Creoles language family
 
 ---
 

--- a/languages/crimean-tatar.md
+++ b/languages/crimean-tatar.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Crimean Tatar
 
 ---
 

--- a/languages/croatian.md
+++ b/languages/croatian.md
@@ -109,6 +109,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Croatian
 
 ---
 

--- a/languages/cushitic.md
+++ b/languages/cushitic.md
@@ -10,6 +10,8 @@ languages:
   name: Oromo
 - slug: somali
   name: Somali
+seo:
+  name: Machine translation for the Cushitic language family
 
 ---
 

--- a/languages/czech.md
+++ b/languages/czech.md
@@ -131,6 +131,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Czech
 
 ---
 

--- a/languages/danish.md
+++ b/languages/danish.md
@@ -135,6 +135,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Danish
 
 ---
 

--- a/languages/dholuo.md
+++ b/languages/dholuo.md
@@ -28,6 +28,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Dholuo
 
 ---
 

--- a/languages/dinka.md
+++ b/languages/dinka.md
@@ -27,6 +27,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Dinka
 
 ---
 

--- a/languages/divehi.md
+++ b/languages/divehi.md
@@ -44,6 +44,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Divehi
 
 ---
 

--- a/languages/dravidian.md
+++ b/languages/dravidian.md
@@ -14,6 +14,8 @@ languages:
   name: Tamil
 - slug: telugu
   name: Telugu
+seo:
+  name: Machine translation for the Dravidian language family
 
 ---
 

--- a/languages/dutch.md
+++ b/languages/dutch.md
@@ -162,6 +162,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Dutch
 
 ---
 

--- a/languages/dyula.md
+++ b/languages/dyula.md
@@ -35,6 +35,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Dyula
 
 ---
 

--- a/languages/dzongkha.md
+++ b/languages/dzongkha.md
@@ -31,6 +31,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Dzongkha
 
 ---
 

--- a/languages/english-based-creoles.md
+++ b/languages/english-based-creoles.md
@@ -10,6 +10,8 @@ languages:
   name: Bislama
 - slug: tok-pisin
   name: Tok Pisin
+seo:
+  name: Machine translation for the English-based creoles language family
 
 ---
 

--- a/languages/english.md
+++ b/languages/english.md
@@ -210,6 +210,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for English
 
 ---
 

--- a/languages/eskimo-aleut.md
+++ b/languages/eskimo-aleut.md
@@ -8,6 +8,8 @@ code: esx
 languages:
 - slug: inuktitut
   name: Inuktitut
+seo:
+  name: Machine translation for the Eskimo-Aleut language family
 
 ---
 

--- a/languages/esperanto.md
+++ b/languages/esperanto.md
@@ -58,6 +58,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Esperanto
 
 ---
 

--- a/languages/estonian.md
+++ b/languages/estonian.md
@@ -113,6 +113,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Estonian
 
 ---
 

--- a/languages/ewe.md
+++ b/languages/ewe.md
@@ -39,6 +39,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Ewe
 
 ---
 

--- a/languages/faroese.md
+++ b/languages/faroese.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Faroese
 
 ---
 

--- a/languages/fijian.md
+++ b/languages/fijian.md
@@ -43,6 +43,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Fijian
 
 ---
 

--- a/languages/finnish.md
+++ b/languages/finnish.md
@@ -127,6 +127,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Finnish
 
 ---
 

--- a/languages/finno-ugric.md
+++ b/languages/finno-ugric.md
@@ -20,6 +20,8 @@ languages:
   name: Northern Sami
 - slug: udmurt
   name: Udmurt
+seo:
+  name: Machine translation for the Finno-Ugric language family
 
 ---
 

--- a/languages/fon.md
+++ b/languages/fon.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Fon
 
 ---
 

--- a/languages/french-based-creoles.md
+++ b/languages/french-based-creoles.md
@@ -8,6 +8,8 @@ code: cpf
 languages:
 - slug: haitian
   name: Haitian
+seo:
+  name: Machine translation for the French-based creoles language family
 
 ---
 

--- a/languages/french.md
+++ b/languages/french.md
@@ -192,6 +192,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for French
 
 ---
 French is one of the best supported languages for machine translation.

--- a/languages/frisian.md
+++ b/languages/frisian.md
@@ -48,6 +48,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Frisian
 
 ---
 

--- a/languages/friulian.md
+++ b/languages/friulian.md
@@ -33,6 +33,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Friulian
 
 ---
 

--- a/languages/fula.md
+++ b/languages/fula.md
@@ -34,6 +34,8 @@ supported_apis:
 - id: baidu
   name: Baidu Translate
   supported_language_count: 197
+seo:
+  name: Machine translation for Fula
 
 ---
 

--- a/languages/galician.md
+++ b/languages/galician.md
@@ -73,6 +73,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Galician
 
 ---
 

--- a/languages/ganda.md
+++ b/languages/ganda.md
@@ -26,6 +26,8 @@ typology:
 territories:
 - ug
 supported_apis: []
+seo:
+  name: Machine translation for Ganda
 
 ---
 

--- a/languages/georgian.md
+++ b/languages/georgian.md
@@ -72,6 +72,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Georgian
 
 ---
 

--- a/languages/german.md
+++ b/languages/german.md
@@ -180,6 +180,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for German
 
 ---
 

--- a/languages/germanic.md
+++ b/languages/germanic.md
@@ -34,6 +34,8 @@ languages:
   name: Swedish
 - slug: yiddish
   name: Yiddish
+seo:
+  name: Machine translation for the Germanic language family
 
 ---
 

--- a/languages/greek.md
+++ b/languages/greek.md
@@ -114,6 +114,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Greek
 
 ---
 

--- a/languages/guarani.md
+++ b/languages/guarani.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Guarani
 
 ---
 

--- a/languages/gujarati.md
+++ b/languages/gujarati.md
@@ -75,6 +75,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Gujarati
 
 ---
 

--- a/languages/haitian.md
+++ b/languages/haitian.md
@@ -68,6 +68,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Haitian
 
 ---
 

--- a/languages/hausa.md
+++ b/languages/hausa.md
@@ -61,6 +61,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Hausa
 
 ---
 

--- a/languages/hawaiian.md
+++ b/languages/hawaiian.md
@@ -42,6 +42,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Hawaiian
 
 ---
 

--- a/languages/hebrew.md
+++ b/languages/hebrew.md
@@ -114,6 +114,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Hebrew
 
 ---
 

--- a/languages/hellenic.md
+++ b/languages/hellenic.md
@@ -8,6 +8,8 @@ code: grk
 languages:
 - slug: greek
   name: Greek
+seo:
+  name: Machine translation for the Hellenic language family
 
 ---
 

--- a/languages/hill-mari.md
+++ b/languages/hill-mari.md
@@ -28,6 +28,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Hill Mari
 
 ---
 

--- a/languages/hindi.md
+++ b/languages/hindi.md
@@ -132,6 +132,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Hindi
 
 ---
 

--- a/languages/hmong-mien.md
+++ b/languages/hmong-mien.md
@@ -8,6 +8,8 @@ code: hmx
 languages:
 - slug: hmong
   name: Hmong
+seo:
+  name: Machine translation for the Hmong-Mien language family
 
 ---
 

--- a/languages/hmong.md
+++ b/languages/hmong.md
@@ -81,6 +81,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Hmong
 
 ---
 

--- a/languages/hungarian.md
+++ b/languages/hungarian.md
@@ -133,6 +133,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Hungarian
 
 ---
 

--- a/languages/icelandic.md
+++ b/languages/icelandic.md
@@ -82,6 +82,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Icelandic
 
 ---
 

--- a/languages/igbo.md
+++ b/languages/igbo.md
@@ -49,6 +49,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Igbo
 
 ---
 

--- a/languages/ilocano.md
+++ b/languages/ilocano.md
@@ -34,6 +34,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Ilocano
 
 ---
 

--- a/languages/indo-aryan.md
+++ b/languages/indo-aryan.md
@@ -40,6 +40,8 @@ languages:
   name: Urdu
 - slug: venetian
   name: Venetian
+seo:
+  name: Machine translation for the Indo-Aryan language family
 
 ---
 

--- a/languages/indo-european.md
+++ b/languages/indo-european.md
@@ -180,6 +180,8 @@ languages:
   name: Yiddish
 - slug: zaza
   name: Zaza
+seo:
+  name: Machine translation for the Indo-European language family
 
 ---
 

--- a/languages/indo-iranian.md
+++ b/languages/indo-iranian.md
@@ -58,6 +58,8 @@ languages:
   name: Urdu
 - slug: zaza
   name: Zaza
+seo:
+  name: Machine translation for the Indo-Iranian language family
 
 ---
 

--- a/languages/indonesian.md
+++ b/languages/indonesian.md
@@ -131,6 +131,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Indonesian
 
 ---
 

--- a/languages/inuktitut.md
+++ b/languages/inuktitut.md
@@ -35,6 +35,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Inuktitut
 
 ---
 

--- a/languages/iranic.md
+++ b/languages/iranic.md
@@ -24,6 +24,8 @@ languages:
   name: Sorani Kurdish
 - slug: tajik
   name: Tajik
+seo:
+  name: Machine translation for the Iranic language family
 
 ---
 

--- a/languages/irish.md
+++ b/languages/irish.md
@@ -80,6 +80,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Irish
 
 ---
 

--- a/languages/iroquoian.md
+++ b/languages/iroquoian.md
@@ -8,6 +8,8 @@ code: iro
 languages:
 - slug: cherokee
   name: Cherokee
+seo:
+  name: Machine translation for the Iroquoian language family
 
 ---
 

--- a/languages/italian.md
+++ b/languages/italian.md
@@ -167,6 +167,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Italian
 
 ---
 

--- a/languages/japanese.md
+++ b/languages/japanese.md
@@ -149,6 +149,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Japanese
 
 ---
 

--- a/languages/japonic.md
+++ b/languages/japonic.md
@@ -8,6 +8,8 @@ code: jpx
 languages:
 - slug: japanese
   name: Japanese
+seo:
+  name: Machine translation for the Japonic language family
 
 ---
 

--- a/languages/javanese.md
+++ b/languages/javanese.md
@@ -57,6 +57,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Javanese
 
 ---
 

--- a/languages/jingpho.md
+++ b/languages/jingpho.md
@@ -33,6 +33,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Jingpho
 
 ---
 

--- a/languages/kabiye.md
+++ b/languages/kabiye.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kabiye
 
 ---
 

--- a/languages/kabyle.md
+++ b/languages/kabyle.md
@@ -35,6 +35,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kabyle
 
 ---
 

--- a/languages/kamba.md
+++ b/languages/kamba.md
@@ -32,6 +32,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kamba
 
 ---
 

--- a/languages/kannada.md
+++ b/languages/kannada.md
@@ -68,6 +68,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kannada
 
 ---
 

--- a/languages/kanuri.md
+++ b/languages/kanuri.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Kanuri
 
 ---
 

--- a/languages/kartvelian.md
+++ b/languages/kartvelian.md
@@ -8,6 +8,8 @@ code: ccs
 languages:
 - slug: georgian
   name: Georgian
+seo:
+  name: Machine translation for the Kartvelian language family
 
 ---
 

--- a/languages/kashmiri.md
+++ b/languages/kashmiri.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Kashmiri
 
 ---
 

--- a/languages/kazakh.md
+++ b/languages/kazakh.md
@@ -75,6 +75,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kazakh
 
 ---
 

--- a/languages/khmer.md
+++ b/languages/khmer.md
@@ -66,6 +66,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Khmer
 
 ---
 

--- a/languages/kikuyu.md
+++ b/languages/kikuyu.md
@@ -31,6 +31,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kikuyu
 
 ---
 

--- a/languages/kimbundu.md
+++ b/languages/kimbundu.md
@@ -30,6 +30,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kimbundu
 
 ---
 

--- a/languages/kinyarwanda.md
+++ b/languages/kinyarwanda.md
@@ -47,6 +47,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kinyarwanda
 
 ---
 

--- a/languages/kirundi.md
+++ b/languages/kirundi.md
@@ -37,6 +37,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kirundi
 
 ---
 

--- a/languages/klingon.md
+++ b/languages/klingon.md
@@ -31,6 +31,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Klingon
 
 ---
 

--- a/languages/kongo.md
+++ b/languages/kongo.md
@@ -37,6 +37,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kongo
 
 ---
 

--- a/languages/korean.md
+++ b/languages/korean.md
@@ -145,6 +145,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Korean
 
 ---
 

--- a/languages/koreanic.md
+++ b/languages/koreanic.md
@@ -8,6 +8,8 @@ code: kor
 languages:
 - slug: korean
   name: Korean
+seo:
+  name: Machine translation for the Koreanic language family
 
 ---
 

--- a/languages/kurdish.md
+++ b/languages/kurdish.md
@@ -71,6 +71,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kurdish
 
 ---
 

--- a/languages/kyrgyz.md
+++ b/languages/kyrgyz.md
@@ -60,6 +60,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Kyrgyz
 
 ---
 

--- a/languages/lao.md
+++ b/languages/lao.md
@@ -58,6 +58,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Lao
 
 ---
 

--- a/languages/latgalian.md
+++ b/languages/latgalian.md
@@ -33,6 +33,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Latgalian
 
 ---
 

--- a/languages/latin.md
+++ b/languages/latin.md
@@ -52,6 +52,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Latin
 
 ---
 

--- a/languages/latvian.md
+++ b/languages/latvian.md
@@ -113,6 +113,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Latvian
 
 ---
 

--- a/languages/ligurian.md
+++ b/languages/ligurian.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Ligurian
 
 ---
 

--- a/languages/limburgish.md
+++ b/languages/limburgish.md
@@ -37,6 +37,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Limburgish
 
 ---
 

--- a/languages/lingala.md
+++ b/languages/lingala.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Lingala
 
 ---
 

--- a/languages/lithuanian.md
+++ b/languages/lithuanian.md
@@ -111,6 +111,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Lithuanian
 
 ---
 

--- a/languages/lombard.md
+++ b/languages/lombard.md
@@ -27,6 +27,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Lombard
 
 ---
 

--- a/languages/luba-kasai.md
+++ b/languages/luba-kasai.md
@@ -31,6 +31,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Luba-Kasai
 
 ---
 

--- a/languages/luxembourgish.md
+++ b/languages/luxembourgish.md
@@ -57,6 +57,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Luxembourgish
 
 ---
 

--- a/languages/macedonian.md
+++ b/languages/macedonian.md
@@ -71,6 +71,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Macedonian
 
 ---
 

--- a/languages/magahi.md
+++ b/languages/magahi.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Magahi
 
 ---
 

--- a/languages/maithili.md
+++ b/languages/maithili.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Maithili
 
 ---
 

--- a/languages/malagasy.md
+++ b/languages/malagasy.md
@@ -83,6 +83,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Malagasy
 
 ---
 

--- a/languages/malay.md
+++ b/languages/malay.md
@@ -111,6 +111,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Malay
 
 ---
 

--- a/languages/malayalam.md
+++ b/languages/malayalam.md
@@ -63,6 +63,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Malayalam
 
 ---
 

--- a/languages/malaysian-malay.md
+++ b/languages/malaysian-malay.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Malaysian Malay
 
 ---
 

--- a/languages/maltese.md
+++ b/languages/maltese.md
@@ -90,6 +90,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Maltese
 
 ---
 

--- a/languages/mande.md
+++ b/languages/mande.md
@@ -10,6 +10,8 @@ languages:
   name: Bambara
 - slug: dyula
   name: Dyula
+seo:
+  name: Machine translation for the Mande language family
 
 ---
 

--- a/languages/manx.md
+++ b/languages/manx.md
@@ -34,6 +34,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Manx
 
 ---
 

--- a/languages/maori.md
+++ b/languages/maori.md
@@ -58,6 +58,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Maori
 
 ---
 

--- a/languages/marathi.md
+++ b/languages/marathi.md
@@ -71,6 +71,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Marathi
 
 ---
 

--- a/languages/marshallese.md
+++ b/languages/marshallese.md
@@ -33,6 +33,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Marshallese
 
 ---
 

--- a/languages/mayan.md
+++ b/languages/mayan.md
@@ -8,6 +8,8 @@ code: myn
 languages:
 - slug: yucatec-maya
   name: Yucatec Maya
+seo:
+  name: Machine translation for the Mayan language family
 
 ---
 

--- a/languages/meadow-mari.md
+++ b/languages/meadow-mari.md
@@ -28,6 +28,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Meadow Mari
 
 ---
 

--- a/languages/meitei.md
+++ b/languages/meitei.md
@@ -34,6 +34,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Meitei
 
 ---
 

--- a/languages/minangkabau.md
+++ b/languages/minangkabau.md
@@ -23,6 +23,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Minangkabau
 
 ---
 

--- a/languages/mizo.md
+++ b/languages/mizo.md
@@ -33,6 +33,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Mizo
 
 ---
 

--- a/languages/mongolian.md
+++ b/languages/mongolian.md
@@ -67,6 +67,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Mongolian
 
 ---
 

--- a/languages/mongolic.md
+++ b/languages/mongolic.md
@@ -8,6 +8,8 @@ code: xgn
 languages:
 - slug: mongolian
   name: Mongolian
+seo:
+  name: Machine translation for the Mongolic language family
 
 ---
 

--- a/languages/montenegrin.md
+++ b/languages/montenegrin.md
@@ -39,6 +39,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Montenegrin
 
 ---
 

--- a/languages/moore.md
+++ b/languages/moore.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Moore
 
 ---
 

--- a/languages/nepali.md
+++ b/languages/nepali.md
@@ -65,6 +65,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Nepali
 
 ---
 

--- a/languages/niger-congo.md
+++ b/languages/niger-congo.md
@@ -74,6 +74,8 @@ languages:
   name: Yoruba
 - slug: zulu
   name: Zulu
+seo:
+  name: Machine translation for the Niger-Congo language family
 
 ---
 

--- a/languages/nilo-saharan.md
+++ b/languages/nilo-saharan.md
@@ -16,6 +16,8 @@ languages:
   name: Kanuri
 - slug: nuer
   name: Nuer
+seo:
+  name: Machine translation for the Nilo-Saharan language family
 
 ---
 

--- a/languages/northern-sami.md
+++ b/languages/northern-sami.md
@@ -37,6 +37,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Northern Sami
 
 ---
 

--- a/languages/northern-sotho.md
+++ b/languages/northern-sotho.md
@@ -32,6 +32,8 @@ supported_apis:
 - id: baidu
   name: Baidu Translate
   supported_language_count: 197
+seo:
+  name: Machine translation for Northern Sotho
 
 ---
 

--- a/languages/northwestern-otomi.md
+++ b/languages/northwestern-otomi.md
@@ -28,6 +28,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Northwestern Otomi
 
 ---
 

--- a/languages/norwegian.md
+++ b/languages/norwegian.md
@@ -105,6 +105,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Norwegian
 
 ---
 

--- a/languages/nuer.md
+++ b/languages/nuer.md
@@ -26,6 +26,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Nuer
 
 ---
 

--- a/languages/occitan.md
+++ b/languages/occitan.md
@@ -39,6 +39,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Occitan
 
 ---
 

--- a/languages/oriya.md
+++ b/languages/oriya.md
@@ -48,6 +48,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Oriya
 
 ---
 

--- a/languages/oromo.md
+++ b/languages/oromo.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Oromo
 
 ---
 

--- a/languages/ossetian.md
+++ b/languages/ossetian.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Ossetian
 
 ---
 

--- a/languages/oto-manguean.md
+++ b/languages/oto-manguean.md
@@ -8,6 +8,8 @@ code: omq
 languages:
 - slug: northwestern-otomi
   name: Northwestern Otomi
+seo:
+  name: Machine translation for the Oto-Manguean language family
 
 ---
 

--- a/languages/pangasinan.md
+++ b/languages/pangasinan.md
@@ -30,6 +30,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Pangasinan
 
 ---
 

--- a/languages/papiamento.md
+++ b/languages/papiamento.md
@@ -37,6 +37,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Papiamento
 
 ---
 

--- a/languages/pashto.md
+++ b/languages/pashto.md
@@ -68,6 +68,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Pashto
 
 ---
 

--- a/languages/persian.md
+++ b/languages/persian.md
@@ -106,6 +106,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Persian
 
 ---
 

--- a/languages/polish.md
+++ b/languages/polish.md
@@ -136,6 +136,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Polish
 
 ---
 

--- a/languages/portuguese-based-creoles.md
+++ b/languages/portuguese-based-creoles.md
@@ -10,6 +10,8 @@ languages:
   name: Cape Verdean Creole
 - slug: papiamento
   name: Papiamento
+seo:
+  name: Machine translation for the Portuguese-based creoles language family
 
 ---
 

--- a/languages/portuguese.md
+++ b/languages/portuguese.md
@@ -167,6 +167,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Portuguese
 
 ---
 Portuguese was one of the first languages for which machine translation APIs supported multiple variants.

--- a/languages/punjabi.md
+++ b/languages/punjabi.md
@@ -77,6 +77,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Punjabi
 
 ---
 

--- a/languages/quechua.md
+++ b/languages/quechua.md
@@ -36,6 +36,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Quechua
 
 ---
 

--- a/languages/quechuan.md
+++ b/languages/quechuan.md
@@ -10,6 +10,8 @@ languages:
   name: Ayacucho
 - slug: quechua
   name: Quechua
+seo:
+  name: Machine translation for the Quechuan language family
 
 ---
 

--- a/languages/romance.md
+++ b/languages/romance.md
@@ -46,6 +46,8 @@ languages:
   name: Spanish
 - slug: venetian
   name: Venetian
+seo:
+  name: Machine translation for the Romance language family
 
 ---
 

--- a/languages/romanian.md
+++ b/languages/romanian.md
@@ -122,6 +122,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Romanian
 
 ---
 

--- a/languages/romansh.md
+++ b/languages/romansh.md
@@ -35,6 +35,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Romansh
 
 ---
 

--- a/languages/russian.md
+++ b/languages/russian.md
@@ -173,6 +173,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Russian
 
 ---
 Russian was one of the first languages for which machine translation was researched and developed, and remains one of the best supported languages.

--- a/languages/samoan.md
+++ b/languages/samoan.md
@@ -55,6 +55,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Samoan
 
 ---
 

--- a/languages/sango.md
+++ b/languages/sango.md
@@ -35,6 +35,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Sango
 
 ---
 

--- a/languages/sanskrit.md
+++ b/languages/sanskrit.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Sanskrit
 
 ---
 

--- a/languages/santali.md
+++ b/languages/santali.md
@@ -28,6 +28,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Santali
 
 ---
 

--- a/languages/sardinian.md
+++ b/languages/sardinian.md
@@ -35,6 +35,8 @@ supported_apis:
 - id: baidu
   name: Baidu Translate
   supported_language_count: 197
+seo:
+  name: Machine translation for Sardinian
 
 ---
 

--- a/languages/scottish-gaelic.md
+++ b/languages/scottish-gaelic.md
@@ -50,6 +50,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Scottish Gaelic
 
 ---
 

--- a/languages/semitic.md
+++ b/languages/semitic.md
@@ -18,6 +18,8 @@ languages:
   name: Maltese
 - slug: tigrinya
   name: Tigrinya
+seo:
+  name: Machine translation for the Semitic language family
 
 ---
 

--- a/languages/serbian.md
+++ b/languages/serbian.md
@@ -98,6 +98,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Serbian
 
 ---
 

--- a/languages/shan.md
+++ b/languages/shan.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Shan
 
 ---
 

--- a/languages/shona.md
+++ b/languages/shona.md
@@ -46,6 +46,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Shona
 
 ---
 

--- a/languages/sicilian.md
+++ b/languages/sicilian.md
@@ -26,6 +26,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Sicilian
 
 ---
 

--- a/languages/silesian.md
+++ b/languages/silesian.md
@@ -31,6 +31,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Silesian
 
 ---
 

--- a/languages/sindhi.md
+++ b/languages/sindhi.md
@@ -54,6 +54,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Sindhi
 
 ---
 

--- a/languages/sinhala.md
+++ b/languages/sinhala.md
@@ -72,6 +72,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Sinhala
 
 ---
 

--- a/languages/sino-tibetan.md
+++ b/languages/sino-tibetan.md
@@ -22,6 +22,8 @@ languages:
   name: Mizo
 - slug: tibetan
   name: Tibetan
+seo:
+  name: Machine translation for the Sino-Tibetan language family
 
 ---
 

--- a/languages/slavic.md
+++ b/languages/slavic.md
@@ -36,6 +36,8 @@ languages:
   name: Ukrainian
 - slug: upper-sorbian
   name: Upper Sorbian
+seo:
+  name: Machine translation for the Slavic language family
 
 ---
 

--- a/languages/slovak.md
+++ b/languages/slovak.md
@@ -118,6 +118,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Slovak
 
 ---
 

--- a/languages/slovenian.md
+++ b/languages/slovenian.md
@@ -113,6 +113,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Slovenian
 
 ---
 

--- a/languages/somali.md
+++ b/languages/somali.md
@@ -77,6 +77,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Somali
 
 ---
 

--- a/languages/sorani-kurdish.md
+++ b/languages/sorani-kurdish.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Sorani Kurdish
 
 ---
 

--- a/languages/sotho.md
+++ b/languages/sotho.md
@@ -48,6 +48,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Sotho
 
 ---
 

--- a/languages/spanish.md
+++ b/languages/spanish.md
@@ -204,6 +204,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Spanish
 
 ---
 Spanish is one of the best supported languages for machine translation.

--- a/languages/sundanese.md
+++ b/languages/sundanese.md
@@ -45,6 +45,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Sundanese
 
 ---
 

--- a/languages/swahili.md
+++ b/languages/swahili.md
@@ -84,6 +84,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Swahili
 
 ---
 

--- a/languages/swati.md
+++ b/languages/swati.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Swati
 
 ---
 

--- a/languages/swedish.md
+++ b/languages/swedish.md
@@ -137,6 +137,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Swedish
 
 ---
 

--- a/languages/tagalog.md
+++ b/languages/tagalog.md
@@ -87,6 +87,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tagalog
 
 ---
 

--- a/languages/tahitian.md
+++ b/languages/tahitian.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tahitian
 
 ---
 

--- a/languages/tai.md
+++ b/languages/tai.md
@@ -12,6 +12,8 @@ languages:
   name: Shan
 - slug: thai
   name: Thai
+seo:
+  name: Machine translation for the Tai language family
 
 ---
 

--- a/languages/tajik.md
+++ b/languages/tajik.md
@@ -66,6 +66,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tajik
 
 ---
 

--- a/languages/tamasheq.md
+++ b/languages/tamasheq.md
@@ -26,6 +26,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Tamasheq
 
 ---
 

--- a/languages/tamil.md
+++ b/languages/tamil.md
@@ -76,6 +76,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tamil
 
 ---
 

--- a/languages/tatar.md
+++ b/languages/tatar.md
@@ -55,6 +55,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tatar
 
 ---
 

--- a/languages/telugu.md
+++ b/languages/telugu.md
@@ -67,6 +67,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Telugu
 
 ---
 

--- a/languages/tetum.md
+++ b/languages/tetum.md
@@ -34,6 +34,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tetum
 
 ---
 

--- a/languages/thai.md
+++ b/languages/thai.md
@@ -129,6 +129,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Thai
 
 ---
 

--- a/languages/tibetan.md
+++ b/languages/tibetan.md
@@ -36,6 +36,8 @@ supported_apis:
 - id: baidu
   name: Baidu Translate
   supported_language_count: 197
+seo:
+  name: Machine translation for Tibetan
 
 ---
 

--- a/languages/tigrinya.md
+++ b/languages/tigrinya.md
@@ -47,6 +47,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tigrinya
 
 ---
 

--- a/languages/tok-pisin.md
+++ b/languages/tok-pisin.md
@@ -30,6 +30,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tok Pisin
 
 ---
 

--- a/languages/tonga.md
+++ b/languages/tonga.md
@@ -41,6 +41,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tonga
 
 ---
 

--- a/languages/tsonga.md
+++ b/languages/tsonga.md
@@ -41,6 +41,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tsonga
 
 ---
 

--- a/languages/tswana.md
+++ b/languages/tswana.md
@@ -32,6 +32,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tswana
 
 ---
 

--- a/languages/tumbuka.md
+++ b/languages/tumbuka.md
@@ -31,6 +31,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Tumbuka
 
 ---
 

--- a/languages/tupian.md
+++ b/languages/tupian.md
@@ -8,6 +8,8 @@ code: tup
 languages:
 - slug: guarani
   name: Guarani
+seo:
+  name: Machine translation for the Tupian language family
 
 ---
 

--- a/languages/turkic.md
+++ b/languages/turkic.md
@@ -28,6 +28,8 @@ languages:
   name: Uyghur
 - slug: uzbek
   name: Uzbek
+seo:
+  name: Machine translation for the Turkic language family
 
 ---
 

--- a/languages/turkish.md
+++ b/languages/turkish.md
@@ -140,6 +140,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Turkish
 
 ---
 Turkish is the language with the best machine translation support in the Turkic language family.  

--- a/languages/turkmen.md
+++ b/languages/turkmen.md
@@ -60,6 +60,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Turkmen
 
 ---
 

--- a/languages/twi.md
+++ b/languages/twi.md
@@ -34,6 +34,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Twi
 
 ---
 

--- a/languages/udmurt.md
+++ b/languages/udmurt.md
@@ -30,6 +30,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Udmurt
 
 ---
 

--- a/languages/ukrainian.md
+++ b/languages/ukrainian.md
@@ -122,6 +122,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Ukrainian
 
 ---
 

--- a/languages/umbundu.md
+++ b/languages/umbundu.md
@@ -33,6 +33,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Umbundu
 
 ---
 

--- a/languages/upper-sorbian.md
+++ b/languages/upper-sorbian.md
@@ -33,6 +33,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Upper Sorbian
 
 ---
 

--- a/languages/urdu.md
+++ b/languages/urdu.md
@@ -97,6 +97,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Urdu
 
 ---
 

--- a/languages/uyghur.md
+++ b/languages/uyghur.md
@@ -40,6 +40,8 @@ supported_apis:
 - id: baidu
   name: Baidu Translate
   supported_language_count: 197
+seo:
+  name: Machine translation for Uyghur
 
 ---
 

--- a/languages/uzbek.md
+++ b/languages/uzbek.md
@@ -68,6 +68,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Uzbek
 
 ---
 

--- a/languages/venda.md
+++ b/languages/venda.md
@@ -36,6 +36,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Venda
 
 ---
 

--- a/languages/venetian.md
+++ b/languages/venetian.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: modernmt
   name: ModernMT
   supported_language_count: 195
+seo:
+  name: Machine translation for Venetian
 
 ---
 

--- a/languages/vietnamese.md
+++ b/languages/vietnamese.md
@@ -120,6 +120,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Vietnamese
 
 ---
 

--- a/languages/waray.md
+++ b/languages/waray.md
@@ -33,6 +33,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Waray
 
 ---
 

--- a/languages/welsh.md
+++ b/languages/welsh.md
@@ -79,6 +79,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Welsh
 
 ---
 

--- a/languages/wolof.md
+++ b/languages/wolof.md
@@ -38,6 +38,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Wolof
 
 ---
 

--- a/languages/xhosa.md
+++ b/languages/xhosa.md
@@ -52,6 +52,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Xhosa
 
 ---
 

--- a/languages/yiddish.md
+++ b/languages/yiddish.md
@@ -62,6 +62,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Yiddish
 
 ---
 

--- a/languages/yoruba.md
+++ b/languages/yoruba.md
@@ -45,6 +45,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Yoruba
 
 ---
 

--- a/languages/yucatec-maya.md
+++ b/languages/yucatec-maya.md
@@ -28,6 +28,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Yucatec Maya
 
 ---
 

--- a/languages/zaza.md
+++ b/languages/zaza.md
@@ -29,6 +29,8 @@ supported_apis:
 - id: alibaba
   name: Alibaba Translate
   supported_language_count: 212
+seo:
+  name: Machine translation for Zaza
 
 ---
 

--- a/languages/zulu.md
+++ b/languages/zulu.md
@@ -57,6 +57,8 @@ supported_apis:
 - id: niutrans
   name: Niutrans
   supported_language_count: 381
+seo:
+  name: Machine translation for Zulu
 
 ---
 


### PR DESCRIPTION
# Description

Use page description, not title, as the page title or SEO purposes, in auto-generated pages

## Type of PR

- Meta / infra

### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
