### PR TITLE
Note about `als` in alemannic.md and albanian.md

### DIFF
--- a/languages/albanian.md
+++ b/languages/albanian.md
@@ -91,3 +91,4 @@ seo:
 
 ---
 
+The language code `als` is the ISO 639-3 code for Tosk Albanian, but it is used by Wikipedia for [Alemannic](/languages/alemannic).

--- a/languages/albanian.md
+++ b/languages/albanian.md
@@ -91,4 +91,4 @@ seo:
 
 ---
 
-The language code `als` is the ISO 639-3 code for Tosk Albanian, but it is used by Wikipedia for [Alemannic](/languages/alemannic).
+The language code `als` is the ISO 639-3 code for Tosk Albanian, but it is used by Wikipedia for [Alemannic](/languages/alemannic.md).

--- a/languages/alemannic.md
+++ b/languages/alemannic.md
@@ -48,3 +48,4 @@ seo:
 
 ---
 
+The language code `als` is also used for Alemannic, for example by Wikipedia, but it is actually the ISO 639-3 code for [Tosk Albanian](/languages/albanian).

--- a/languages/alemannic.md
+++ b/languages/alemannic.md
@@ -48,4 +48,4 @@ seo:
 
 ---
 
-Wikipedia uses the language code `als` for Alemannic, but it is actually the ISO 639-3 code for [Tosk Albanian](/languages/albanian).
+Wikipedia uses the language code `als` for Alemannic, but it is actually the ISO 639-3 code for [Tosk Albanian](/languages/albanian.md).

--- a/languages/alemannic.md
+++ b/languages/alemannic.md
@@ -48,4 +48,4 @@ seo:
 
 ---
 
-The language code `als` is also used for Alemannic, for example by Wikipedia, but it is actually the ISO 639-3 code for [Tosk Albanian](/languages/albanian).
+Wikipedia uses the language code `als` for Alemannic, but it is actually the ISO 639-3 code for [Tosk Albanian](/languages/albanian).


### PR DESCRIPTION
Disambiguate `als` for Albanian and Alemannic

# Description

This language code is used improperly by Wikipedia.

## Type of PR

- Edits *Alemannic* and *Albanian*


### Checklist:

- [x] I have read the [contributing guidelines](contributing.md).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
