### PR TITLE
Change aggregator wording

### DIFF
--- a/_layouts/aggregator.html
+++ b/_layouts/aggregator.html
@@ -54,7 +54,7 @@ parent: Aggregators
       {% if page.supported_apis.size == 1 %}
         <strong>1</strong> machine translation API supports {{ page.title }}.
       {% else %}
-        <strong>{{ page.supported_apis | size }}</strong> machine translation APIs support {{ page.title }}.
+        <strong>{{ page.supported_apis | size }}</strong> machine translation APIs are supported by the {{ page.title }} aggregator.
       {% endif %}
       <p class="preview hint">
         {{ page.supported_apis | slice: 0, 5 | map: 'name' | join: ', ' }}


### PR DESCRIPTION

# Description

The wording was backwards.  The APIs don't support the aggregator, the aggregator supports the APIs.

## Type of PR

- Edits all the generated articles in /aggregators


### Checklist:

- [x] I have read the [contributing guidelines](/CONTRIBUTING).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
