### PR TITLE
Add KantanStream and Google Cloud Translation Hub

### DIFF
--- a/_data/integrations.json
+++ b/_data/integrations.json
@@ -240,6 +240,7 @@
                     "glossary": true,
                     "adaptive": true
                 }
+            }
         ],
         "quality_estimation_integrations": [
             {
@@ -1470,6 +1471,7 @@
                     "custom": true,
                     "glossary": true
                 }
+            }
         ],
         "quality_estimation_integrations": [
             {


### PR DESCRIPTION
Not very significant TMSes, but the quality estimation pages need to link to these.

# Description

This allows us to add CI with everything green (#582).

## Type of PR

- Creates the articles _KantanStream_ and _Google Cloud Translation Hub_

### Checklist:

- [x] I have read the [contributing guidelines](/CONTRIBUTING).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
