### PR TITLE
Create wmt24.md

### DIFF
--- a/events/events.md
+++ b/events/events.md
@@ -46,8 +46,8 @@ seo:
 
 | Date | Event | Location |
 | --- | --- | --- |
-|  | **WMT24** |  |
 | 2 December | Language AI Meetup | Zurich, Switzerland |
+| 12 - 13 November | [**WMT24**](/wmt24) | Florida |
 | 30 September | [**AMTA 2024**](/amta2024) | Chicago, Illinois |
 | 16 September | Language AI Meetup | Zurich, Switzerland |
 | 15 - 16 August | [**IWSLT 2024**](/iwslt2024) | Bangkok, Thailand |

--- a/events/wmt23.md
+++ b/events/wmt23.md
@@ -78,23 +78,27 @@ In 2022, the *News* machine translation task was renamed the *General* machine t
 
 ### Research Papers
 
-> Research papers should describe original research corresponding to the categories listed above. Research papers that have been or will be submitted to other meetings or publications must indicate this at submission time, and must be withdrawn from the other venues if accepted and published at WMT 2022.
+> Research papers should describe original research corresponding to the categories listed above.
+Research papers that have been or will be submitted to other meetings or publications must indicate this at submission time, and must be withdrawn from the other venues if accepted and published at WMT 2023.
 
-> We will not accept for publication papers that overlap significantly in content or results with papers that have been or will be published elsewhere. It is acceptable to submit work that has been made available as a technical report (or similar, e.g. in arXiv) without citing it.
+> We will not accept for publication papers that overlap significantly in content or results with papers that have been or will be published elsewhere.
+It is acceptable to submit work that has been made available as a technical report (or similar, e.g. in arXiv) without citing it.
 
 > For the research track, papers should be anonymised, be between 6 and 10 pages in length (excluding references) and may include supplementary material.
 
 
 ### System Papers
 
-> System papers must describe one or more shared task submissions. System paper submissions that we cannot link to a shared task submission will be rejected without review. System papers can overlap with other published work, and do not have to follow the double submission policy. There is no maximum length for system papers, but normally a short paper (4-6 pages) is appropriate. System papers should not be anonymised.
+> System papers must describe one or more shared task submissions.
+System paper submissions that we cannot link to a shared task submission will be rejected without review. System papers can overlap with other published work, and do not have to follow the double submission policy.
+There is no maximum length for system papers, but normally a short paper (4-6 pages) is appropriate. System papers should not be anonymised.
 
 
 ## Paper submission
 
 - Papers must be submitted [electronically](https://www.softconf.com/emnlp2023/wmt/).
 - Research and system papers have the same deadlines.
-- Research and system papers should follow [EMNLP2022 formatting guidelines](https://2023.emnlp.org/calls/style-and-formatting/).
+- Research and system papers should follow [EMNLP2023 formatting guidelines](https://2023.emnlp.org/calls/style-and-formatting/).
 
 ## Schedule
 

--- a/events/wmt23.md
+++ b/events/wmt23.md
@@ -78,20 +78,16 @@ In 2022, the *News* machine translation task was renamed the *General* machine t
 
 ### Research Papers
 
-> Research papers should describe original research corresponding to the categories listed above.
-Research papers that have been or will be submitted to other meetings or publications must indicate this at submission time, and must be withdrawn from the other venues if accepted and published at WMT 2023.
+> Research papers should describe original research corresponding to the categories listed above. Research papers that have been or will be submitted to other meetings or publications must indicate this at submission time, and must be withdrawn from the other venues if accepted and published at WMT 2023.
 
-> We will not accept for publication papers that overlap significantly in content or results with papers that have been or will be published elsewhere.
-It is acceptable to submit work that has been made available as a technical report (or similar, e.g. in arXiv) without citing it.
+> We will not accept for publication papers that overlap significantly in content or results with papers that have been or will be published elsewhere. It is acceptable to submit work that has been made available as a technical report (or similar, e.g. in arXiv) without citing it.
 
 > For the research track, papers should be anonymised, be between 6 and 10 pages in length (excluding references) and may include supplementary material.
 
 
 ### System Papers
 
-> System papers must describe one or more shared task submissions.
-System paper submissions that we cannot link to a shared task submission will be rejected without review. System papers can overlap with other published work, and do not have to follow the double submission policy.
-There is no maximum length for system papers, but normally a short paper (4-6 pages) is appropriate. System papers should not be anonymised.
+> System papers must describe one or more shared task submissions. System paper submissions that we cannot link to a shared task submission will be rejected without review. System papers can overlap with other published work, and do not have to follow the double submission policy. There is no maximum length for system papers, but normally a short paper (4-6 pages) is appropriate. System papers should not be anonymised.
 
 
 ## Paper submission

--- a/events/wmt24.md
+++ b/events/wmt24.md
@@ -63,20 +63,16 @@ Other tasks are yet to be announced.
 
 ### Research Papers
 
-> Research papers should describe original research corresponding to the categories listed above.
-Research papers that have been or will be submitted to other meetings or publications must indicate this at submission time, and must be withdrawn from the other venues if accepted and published at WMT 2024.
+> Research papers should describe original research corresponding to the categories listed above. Research papers that have been or will be submitted to other meetings or publications must indicate this at submission time, and must be withdrawn from the other venues if accepted and published at WMT 2024.
 
-> We will not accept for publication papers that overlap significantly in content or results with papers that have been or will be published elsewhere.
-It is acceptable to submit work that has been made available as a technical report (or similar, e.g. in arXiv) without citing it.
+> We will not accept for publication papers that overlap significantly in content or results with papers that have been or will be published elsewhere. It is acceptable to submit work that has been made available as a technical report (or similar, e.g. in arXiv) without citing it.
 
 > For the research track, papers should be anonymised, be between 6 and 10 pages in length (excluding references) and may include supplementary material.
 
 
 ### System Papers
 
-> System papers must describe one or more shared task submissions.
-System paper submissions that we cannot link to a shared task submission will be rejected without review. System papers can overlap with other published work, and do not have to follow the double submission policy.
-There is no maximum length for system papers, but normally a short paper (4-6 pages) is appropriate. System papers should not be anonymised.
+> System papers must describe one or more shared task submissions. System paper submissions that we cannot link to a shared task submission will be rejected without review. System papers can overlap with other published work, and do not have to follow the double submission policy. There is no maximum length for system papers, but normally a short paper (4-6 pages) is appropriate. System papers should not be anonymised.
 
 
 ## Paper submission

--- a/events/wmt24.md
+++ b/events/wmt24.md
@@ -1,0 +1,86 @@
+---
+parent: Events
+title: WMT24
+description: Ninth Conference on Machine Translation
+location: Florida
+name: WMT24
+startDate: 2024-11-12
+featured: true
+seo:
+  type: Event
+  name: WMT24
+  startDate: 2024-11-12
+  endDate: 2024-11-13
+  eventAttendanceMode: OfflineEventAttendanceMode
+  eventStatus: EventScheduled
+
+  location:
+    type: Place
+    name: Florida, United States of America
+
+  organizer:
+    type: Person
+    url: https://statmt.org/wmt24
+---
+
+The **Ninth Conference on Machine Translation** (**WMT24**) will take place from 12 November to 13 November, 2024, at [EMNLP](http://emnlp.org) 2024 in Florida.
+It is organised by [WMT](/wmt).
+
+[statmt.org/wmt24/](https://statmt.org/wmt24/)
+
+{% include collapsible_toc.html %}
+
+## Important dates
+
+|     |     |
+| --- | --- |
+| Evaluation periods for shared tasks | June-July, 2024 |
+| Paper submission deadline | TBA around 12 August (follows EMNLP) |
+| Paper notification |TBA (follows EMNLP) |
+| Camera-ready version | TBA around 23 September (follows EMNLP) |
+| Conference | 12-13 November, 2024 |
+
+## Shared tasks
+
+- [General translation](https://www2.statmt.org/wmt24/translation-task.html)
+
+Other tasks are yet to be announced.
+
+## Scientific papers
+
+### Topics
+
+- Machine translation models (neural, statistical etc. )
+- Analysis of neural models
+- Using comparable corpora
+- Selection and preparation of data
+- Semi-supervised and unsupervised learning for machine translation, transfer learning
+- Multilingual machine translation
+- Incorporating linguistic information into machine translation
+- Machine translation inference
+- Manual and automatic methods for evaluating machine translation
+- Quality estimation
+
+### Research Papers
+
+> Research papers should describe original research corresponding to the categories listed above.
+Research papers that have been or will be submitted to other meetings or publications must indicate this at submission time, and must be withdrawn from the other venues if accepted and published at WMT 2024.
+
+> We will not accept for publication papers that overlap significantly in content or results with papers that have been or will be published elsewhere.
+It is acceptable to submit work that has been made available as a technical report (or similar, e.g. in arXiv) without citing it.
+
+> For the research track, papers should be anonymised, be between 6 and 10 pages in length (excluding references) and may include supplementary material.
+
+
+### System Papers
+
+> System papers must describe one or more shared task submissions.
+System paper submissions that we cannot link to a shared task submission will be rejected without review. System papers can overlap with other published work, and do not have to follow the double submission policy.
+There is no maximum length for system papers, but normally a short paper (4-6 pages) is appropriate. System papers should not be anonymised.
+
+
+## Paper submission
+
+- Papers must be submitted electronically.
+- Research and system papers have the same deadlines.
+- Research and system papers should follow EMNLP2024 formatting guidelines.

--- a/events/wmt24.md
+++ b/events/wmt24.md
@@ -34,11 +34,11 @@ It is organised by [WMT](/wmt).
 
 |     |     |
 | --- | --- |
-| Evaluation periods for shared tasks | June-July, 2024 |
-| Paper submission deadline | TBA around 12 August (follows EMNLP) |
-| Paper notification |TBA (follows EMNLP) |
-| Camera-ready version | TBA around 23 September (follows EMNLP) |
-| Conference | 12-13 November, 2024 |
+| Evaluation periods for shared tasks | June-July |
+| Paper submission deadline | To be announced around 12 August (follows EMNLP) |
+| Paper notification | To be announced (follows EMNLP) |
+| Camera-ready version | To be announced around 23 September (follows EMNLP) |
+| Conference | 12-13 November |
 
 ## Shared tasks
 


### PR DESCRIPTION
# Description

Dear @cefoo, I've added an article about WMT24. Some details, including the exact location, some shared tasks, and important dates, are yet to be announced. Besides, the EMNLP 2024 event website hasn't been created yet, which is why I haven't included links to paper submission pages or formatting guidelines. Also, I've made minor edits to the WMT23 article, as some information was originally quoted from the previous year's website page, mentioning 2022 instead of 2023.

## Type of PR

- Creates the article _[WMT2024]_

### Checklist:

- [x] I have read the [contributing guidelines](/CONTRIBUTING).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
