### PR TITLE
Update the link to AMAT24 in events.json

### DIFF
--- a/_data/events.json
+++ b/_data/events.json
@@ -14,7 +14,7 @@
        "url": "https://amtaweb.org"
      },
      "links": [
-      "https://2024.amta.org/"
+      "https://amtaweb.org/amta-2024/"
      ],
      "important_dates": [
       {


### PR DESCRIPTION
# Description

Fixes #601

## Type of PR

- Edits `_data/events.json` to reflect the right link to AMTA24.


### Checklist:

- [x] I have read the [contributing guidelines](/CONTRIBUTING).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
