### PR TITLE
Fixing wmt24 dates

### DIFF
--- a/events/wmt24.md
+++ b/events/wmt24.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT24
 end_date: '2024-11-13'
 future_tense_opening_paragraph: The <strong>Ninth Conference on Machine Translation</strong> (<strong>WMT24</strong>)
-  will take place in Miami, Florida from 12 to 12 November, 2024.
+  will take place in Miami, Florida from 12 to 13 November, 2024.
 past_tense_opening_paragraph: The <strong>Ninth Conference on Machine Translation</strong> (<strong>WMT24</strong>)
-  took place in Miami, Florida from 12 to 12 November, 2024.
+  took place in Miami, Florida from 12 to 13 November, 2024.
 name: WMT24
 id: wmt24
 description: Ninth Conference on Machine Translation
@@ -83,7 +83,7 @@ seo:
   name: WMT24
   description: Ninth Conference on Machine Translation
   startDate: '2024-11-12'
-  endDate: '2024-11-12'
+  endDate: '2024-11-13'
   eventAttendanceMode: OfflineEventAttendanceMode
   eventStatus: EventScheduled
   location:


### PR DESCRIPTION
# Description

Dear @cefoo, I've adjusted the conference end date.
Also, I noticed a slight inconsistency with the dates in the `Important dates` section on the website compared to what's specified in `wmt_events.json` and `wmt24.md`. When there's only general text in the date box (like `To be announced (follows EMNLP)`), it looks fine. But when there's a date accompanied by additional text, only the date itself is displayed (e.g., `June-July` appears as `01 June`, `To be announced around 23 September (follows EMNLP)` as `23 September`, and `12-13 November` as `13 November`). 

## Type of PR

- Edits _[WMT24]_

### Checklist:

- [x] I have read the [contributing guidelines](/CONTRIBUTING).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
