### PR TITLE
Fix event date generation

### DIFF
--- a/apis/amazon.md
+++ b/apis/amazon.md
@@ -478,6 +478,7 @@ integrations:
   name: memoQ
   custom: true
   glossary: true
+  formality: true
   urls:
   - https://docs.memoq.com/current/en/Places/amazon-mt-plugin-settings.html
 - slug: phrase-tms

--- a/events/aamt-2021.md
+++ b/events/aamt-2021.md
@@ -8,10 +8,10 @@ title: AAMT 2021
 end_date: '2021-12-09'
 future_tense_opening_paragraph: The Conference of the Asian-Pacific Association for
   Machine Translation (<strong>AAMT 2021</strong>) will take place Online from 08
-  to 09 December, 2021.
+  December to 09 December, 2021.
 past_tense_opening_paragraph: The Conference of the Asian-Pacific Association for
-  Machine Translation (<strong>AAMT 2021</strong>) took place Online from 08 to 09
-  December, 2021.
+  Machine Translation (<strong>AAMT 2021</strong>) took place Online from 08 December
+  to 09 December, 2021.
 name: AAMT 2021
 id: aamt-2021
 description: Conference of the Asian-Pacific Association for Machine Translation

--- a/events/americasnlp-2023.md
+++ b/events/americasnlp-2023.md
@@ -8,10 +8,10 @@ title: AmericasNLP 2023
 end_date: '2023-07-14'
 future_tense_opening_paragraph: The Machine translation for indigenous languages of
   the Americas (<strong>AmericasNLP 2023</strong>) will take place in Toronto, Canada
-  from 09 to 14 July, 2023.
+  from 09 July to 14 July, 2023.
 past_tense_opening_paragraph: The Machine translation for indigenous languages of
   the Americas (<strong>AmericasNLP 2023</strong>) took place in Toronto, Canada from
-  09 to 14 July, 2023.
+  09 July to 14 July, 2023.
 name: AmericasNLP 2023
 id: americasnlp-2023
 description: Machine translation for indigenous languages of the Americas

--- a/events/americasnlp-2024.md
+++ b/events/americasnlp-2024.md
@@ -8,10 +8,10 @@ title: AmericasNLP 2024
 end_date: '2024-06-21'
 future_tense_opening_paragraph: The Machine translation for indigenous languages of
   the Americas (<strong>AmericasNLP 2024</strong>) will take place in Mexico City,
-  Mexico from 20 to 21 June, 2024.
+  Mexico from 20 June to 21 June, 2024.
 past_tense_opening_paragraph: The Machine translation for indigenous languages of
   the Americas (<strong>AmericasNLP 2024</strong>) took place in Mexico City, Mexico
-  from 20 to 21 June, 2024.
+  from 20 June to 21 June, 2024.
 name: AmericasNLP 2024
 id: americasnlp-2024
 description: Machine translation for indigenous languages of the Americas

--- a/events/amta-2020.md
+++ b/events/amta-2020.md
@@ -7,11 +7,11 @@ layout: event
 title: AMTA 2020
 end_date: '2020-10-09'
 future_tense_opening_paragraph: The Conference of the Association of Machine Translation
-  in the Americas (<strong>AMTA 2020</strong>) will take place Online from 05 to 09
-  October, 2020.
+  in the Americas (<strong>AMTA 2020</strong>) will take place Online from 05 October
+  to 09 October, 2020.
 past_tense_opening_paragraph: The Conference of the Association of Machine Translation
-  in the Americas (<strong>AMTA 2020</strong>) took place Online from 05 to 09 October,
-  2020.
+  in the Americas (<strong>AMTA 2020</strong>) took place Online from 05 October to
+  09 October, 2020.
 name: AMTA 2020
 id: amta-2020
 description: Conference of the Association of Machine Translation in the Americas

--- a/events/amta-2022.md
+++ b/events/amta-2022.md
@@ -8,10 +8,10 @@ title: AMTA 2022
 end_date: '2022-09-16'
 future_tense_opening_paragraph: The Conference of the Association for Machine Translation
   in the Americas (<strong>AMTA 2022</strong>) will take place in Florida, United
-  States of America from 12 to 16 September, 2022.
+  States of America from 12 September to 16 September, 2022.
 past_tense_opening_paragraph: The Conference of the Association for Machine Translation
   in the Americas (<strong>AMTA 2022</strong>) took place in Florida, United States
-  of America from 12 to 16 September, 2022.
+  of America from 12 September to 16 September, 2022.
 name: AMTA 2022
 id: amta-2022
 description: Conference of the Association for Machine Translation in the Americas

--- a/events/amta-2024.md
+++ b/events/amta-2024.md
@@ -8,10 +8,10 @@ title: AMTA 2024
 end_date: '2024-10-02'
 future_tense_opening_paragraph: The 16th biennial conference of the Association for
   Machine Translation in the Americas (<strong>AMTA 2024</strong>) will take place
-  in Chicago, Illinois from 30 to 02 October, 2024.
+  in Chicago, Illinois from 30 September to 02 October, 2024.
 past_tense_opening_paragraph: The 16th biennial conference of the Association for
   Machine Translation in the Americas (<strong>AMTA 2024</strong>) took place in Chicago,
-  Illinois from 30 to 02 October, 2024.
+  Illinois from 30 September to 02 October, 2024.
 name: AMTA 2024
 id: amta-2024
 description: 16th biennial conference of the Association for Machine Translation in

--- a/events/coco4mt-2023.md
+++ b/events/coco4mt-2023.md
@@ -8,10 +8,10 @@ title: CoCo4MT 2023
 end_date: '2023-09-05'
 future_tense_opening_paragraph: The Workshop on Corpus Generation and Corpus Augmentation
   for Machine Translation (<strong>CoCo4MT 2023</strong>) will take place in Macau
-  Special Administrative Region, CN from 04 to 05 September, 2023.
+  Special Administrative Region, CN from 04 September to 05 September, 2023.
 past_tense_opening_paragraph: The Workshop on Corpus Generation and Corpus Augmentation
   for Machine Translation (<strong>CoCo4MT 2023</strong>) took place in Macau Special
-  Administrative Region, CN from 04 to 05 September, 2023.
+  Administrative Region, CN from 04 September to 05 September, 2023.
 name: CoCo4MT 2023
 id: coco4mt-2023
 description: Workshop on Corpus Generation and Corpus Augmentation for Machine Translation

--- a/events/convergence-conference-2023.md
+++ b/events/convergence-conference-2023.md
@@ -7,11 +7,11 @@ layout: event
 title: Convergence conference 2023
 end_date: '2023-02-03'
 future_tense_opening_paragraph: The Human-machine integration in translation and interpreting
-  (<strong>Convergence conference 2023</strong>) will take place Online from 01 to
-  03 February, 2023.
+  (<strong>Convergence conference 2023</strong>) will take place Online from 01 February
+  to 03 February, 2023.
 past_tense_opening_paragraph: The Human-machine integration in translation and interpreting
-  (<strong>Convergence conference 2023</strong>) took place Online from 01 to 03 February,
-  2023.
+  (<strong>Convergence conference 2023</strong>) took place Online from 01 February
+  to 03 February, 2023.
 name: Convergence conference 2023
 id: convergence-conference-2023
 description: Human-machine integration in translation and interpreting

--- a/events/eamt-2020.md
+++ b/events/eamt-2020.md
@@ -7,11 +7,11 @@ layout: event
 title: EAMT 2020
 end_date: '2020-11-05'
 future_tense_opening_paragraph: The Conference of the European Association of Machine
-  Translation (<strong>EAMT 2020</strong>) will take place Online from 03 to 05 November,
-  2020.
+  Translation (<strong>EAMT 2020</strong>) will take place Online from 03 November
+  to 05 November, 2020.
 past_tense_opening_paragraph: The Conference of the European Association of Machine
-  Translation (<strong>EAMT 2020</strong>) took place Online from 03 to 05 November,
-  2020.
+  Translation (<strong>EAMT 2020</strong>) took place Online from 03 November to 05
+  November, 2020.
 name: EAMT 2020
 id: eamt-2020
 description: Conference of the European Association of Machine Translation

--- a/events/eamt-2022.md
+++ b/events/eamt-2022.md
@@ -8,10 +8,10 @@ title: EAMT 2022
 end_date: '2022-06-03'
 future_tense_opening_paragraph: The Conference of the European Association of Machine
   Translation (<strong>EAMT 2022</strong>) will take place in Ghent, Belgium from
-  01 to 03 June, 2022.
+  01 June to 03 June, 2022.
 past_tense_opening_paragraph: The Conference of the European Association of Machine
-  Translation (<strong>EAMT 2022</strong>) took place in Ghent, Belgium from 01 to
-  03 June, 2022.
+  Translation (<strong>EAMT 2022</strong>) took place in Ghent, Belgium from 01 June
+  to 03 June, 2022.
 name: EAMT 2022
 id: eamt-2022
 description: Conference of the European Association of Machine Translation

--- a/events/eamt-2023.md
+++ b/events/eamt-2023.md
@@ -8,10 +8,10 @@ title: EAMT 2023
 end_date: '2023-06-15'
 future_tense_opening_paragraph: The Conference of the European Association of Machine
   Translation (<strong>EAMT 2023</strong>) will take place in Tampere, Finland from
-  12 to 15 June, 2023.
+  12 June to 15 June, 2023.
 past_tense_opening_paragraph: The Conference of the European Association of Machine
   Translation (<strong>EAMT 2023</strong>) took place in Tampere, Finland from 12
-  to 15 June, 2023.
+  June to 15 June, 2023.
 name: EAMT 2023
 id: eamt-2023
 description: Conference of the European Association of Machine Translation

--- a/events/eamt-2024.md
+++ b/events/eamt-2024.md
@@ -8,10 +8,10 @@ title: EAMT 2024
 end_date: '2024-06-27'
 future_tense_opening_paragraph: The Conference of the European Association of Machine
   Translation (<strong>EAMT 2024</strong>) will take place in Sheffield, England from
-  24 to 27 June, 2024.
+  24 June to 27 June, 2024.
 past_tense_opening_paragraph: The Conference of the European Association of Machine
   Translation (<strong>EAMT 2024</strong>) took place in Sheffield, England from 24
-  to 27 June, 2024.
+  June to 27 June, 2024.
 name: EAMT 2024
 id: eamt-2024
 description: Conference of the European Association of Machine Translation

--- a/events/iwslt-2022.md
+++ b/events/iwslt-2022.md
@@ -8,10 +8,10 @@ title: IWSLT 2022
 end_date: '2022-05-27'
 future_tense_opening_paragraph: The International Conference on Spoken Language Translation
   (IWSLT) (<strong>IWSLT 2022</strong>) will take place in Dublin, Ireland from 26
-  to 27 May, 2022.
+  May to 27 May, 2022.
 past_tense_opening_paragraph: The International Conference on Spoken Language Translation
-  (IWSLT) (<strong>IWSLT 2022</strong>) took place in Dublin, Ireland from 26 to 27
-  May, 2022.
+  (IWSLT) (<strong>IWSLT 2022</strong>) took place in Dublin, Ireland from 26 May
+  to 27 May, 2022.
 name: IWSLT 2022
 id: iwslt-2022
 description: International Conference on Spoken Language Translation (IWSLT)

--- a/events/iwslt-2023.md
+++ b/events/iwslt-2023.md
@@ -8,10 +8,10 @@ title: IWSLT 2023
 end_date: '2023-07-14'
 future_tense_opening_paragraph: The International Conference on Spoken Language Translation
   (IWSLT) (<strong>IWSLT 2023</strong>) will take place in Toronto, Canada from 13
-  to 14 July, 2023.
+  July to 14 July, 2023.
 past_tense_opening_paragraph: The International Conference on Spoken Language Translation
-  (IWSLT) (<strong>IWSLT 2023</strong>) took place in Toronto, Canada from 13 to 14
-  July, 2023.
+  (IWSLT) (<strong>IWSLT 2023</strong>) took place in Toronto, Canada from 13 July
+  to 14 July, 2023.
 name: IWSLT 2023
 id: iwslt-2023
 description: International Conference on Spoken Language Translation (IWSLT)

--- a/events/iwslt-2024.md
+++ b/events/iwslt-2024.md
@@ -8,10 +8,10 @@ title: IWSLT 2024
 end_date: '2024-08-16'
 future_tense_opening_paragraph: The International Conference on Spoken Language Translation
   (IWSLT) (<strong>IWSLT 2024</strong>) will take place in Bangkok, Thailand and online
-  from 15 to 16 August, 2024.
+  from 15 August to 16 August, 2024.
 past_tense_opening_paragraph: The International Conference on Spoken Language Translation
   (IWSLT) (<strong>IWSLT 2024</strong>) took place in Bangkok, Thailand and online
-  from 15 to 16 August, 2024.
+  from 15 August to 16 August, 2024.
 name: IWSLT 2024
 id: iwslt-2024
 description: International Conference on Spoken Language Translation (IWSLT)

--- a/events/literary-translation-and-ai.md
+++ b/events/literary-translation-and-ai.md
@@ -8,10 +8,10 @@ title: Literary Translation and AI
 end_date: '2022-10-21'
 future_tense_opening_paragraph: The Assessing changes in translation theory, practice
   and creativity (<strong>Literary Translation and AI</strong>) will take place in
-  Paris, France from 20 to 21 October, 2022.
+  Paris, France from 20 October to 21 October, 2022.
 past_tense_opening_paragraph: The Assessing changes in translation theory, practice
   and creativity (<strong>Literary Translation and AI</strong>) took place in Paris,
-  France from 20 to 21 October, 2022.
+  France from 20 October to 21 October, 2022.
 name: Literary Translation and AI
 id: literary-translation-and-ai
 description: Assessing changes in translation theory, practice and creativity

--- a/events/loresmt-2023.md
+++ b/events/loresmt-2023.md
@@ -7,9 +7,9 @@ layout: event
 title: LoResMT 2023
 end_date: '2023-05-06'
 future_tense_opening_paragraph: The Workshop on Low-Resource Machine Translation (<strong>LoResMT
-  2023</strong>) will take place in Dubrovnik, Croatia from 02 to 06 May, 2023.
+  2023</strong>) will take place in Dubrovnik, Croatia from 02 May to 06 May, 2023.
 past_tense_opening_paragraph: The Workshop on Low-Resource Machine Translation (<strong>LoResMT
-  2023</strong>) took place in Dubrovnik, Croatia from 02 to 06 May, 2023.
+  2023</strong>) took place in Dubrovnik, Croatia from 02 May to 06 May, 2023.
 name: LoResMT 2023
 id: loresmt-2023
 description: Workshop on Low-Resource Machine Translation

--- a/events/mt-summit-2013.md
+++ b/events/mt-summit-2013.md
@@ -7,9 +7,10 @@ layout: event
 title: MT Summit 2013
 end_date: '2013-11-06'
 future_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit
-  2013</strong>) will take place in Nice, France from 02 to 06 November, 2013.
+  2013</strong>) will take place in Nice, France from 02 November to 06 November,
+  2013.
 past_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit 2013</strong>)
-  took place in Nice, France from 02 to 06 November, 2013.
+  took place in Nice, France from 02 November to 06 November, 2013.
 name: MT Summit 2013
 id: mt-summit-2013
 description: Machine Translation Summit

--- a/events/mt-summit-2015.md
+++ b/events/mt-summit-2015.md
@@ -7,10 +7,11 @@ layout: event
 title: MT Summit 2015
 end_date: '2015-11-03'
 future_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit
-  2015</strong>) will take place in Florida, United States of America from 29 to 03
-  November, 2015.
+  2015</strong>) will take place in Florida, United States of America from 29 October
+  to 03 November, 2015.
 past_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit 2015</strong>)
-  took place in Florida, United States of America from 29 to 03 November, 2015.
+  took place in Florida, United States of America from 29 October to 03 November,
+  2015.
 name: MT Summit 2015
 id: mt-summit-2015
 description: Machine Translation Summit

--- a/events/mt-summit-2017.md
+++ b/events/mt-summit-2017.md
@@ -7,9 +7,10 @@ layout: event
 title: MT Summit 2017
 end_date: '2017-09-22'
 future_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit
-  2017</strong>) will take place in Nagoya, Japan from 18 to 22 September, 2017.
+  2017</strong>) will take place in Nagoya, Japan from 18 September to 22 September,
+  2017.
 past_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit 2017</strong>)
-  took place in Nagoya, Japan from 18 to 22 September, 2017.
+  took place in Nagoya, Japan from 18 September to 22 September, 2017.
 name: MT Summit 2017
 id: mt-summit-2017
 description: Machine Translation Summit

--- a/events/mt-summit-2019.md
+++ b/events/mt-summit-2019.md
@@ -7,9 +7,9 @@ layout: event
 title: MT Summit 2019
 end_date: '2019-08-23'
 future_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit
-  2019</strong>) will take place in Dublin, Ireland from 19 to 23 August, 2019.
+  2019</strong>) will take place in Dublin, Ireland from 19 August to 23 August, 2019.
 past_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit 2019</strong>)
-  took place in Dublin, Ireland from 19 to 23 August, 2019.
+  took place in Dublin, Ireland from 19 August to 23 August, 2019.
 name: MT Summit 2019
 id: mt-summit-2019
 description: Machine Translation Summit

--- a/events/mt-summit-2021.md
+++ b/events/mt-summit-2021.md
@@ -7,9 +7,9 @@ layout: event
 title: MT Summit 2021
 end_date: '2021-08-20'
 future_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit
-  2021</strong>) will take place Online from 16 to 20 August, 2021.
+  2021</strong>) will take place Online from 16 August to 20 August, 2021.
 past_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit 2021</strong>)
-  took place Online from 16 to 20 August, 2021.
+  took place Online from 16 August to 20 August, 2021.
 name: MT Summit 2021
 id: mt-summit-2021
 description: Machine Translation Summit

--- a/events/mt-summit-2023.md
+++ b/events/mt-summit-2023.md
@@ -8,9 +8,10 @@ title: MT Summit 2023
 end_date: '2023-09-08'
 future_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit
   2023</strong>) will take place in Macau Special Administrative Region, CN from 04
-  to 08 September, 2023.
+  September to 08 September, 2023.
 past_tense_opening_paragraph: The Machine Translation Summit (<strong>MT Summit 2023</strong>)
-  took place in Macau Special Administrative Region, CN from 04 to 08 September, 2023.
+  took place in Macau Special Administrative Region, CN from 04 September to 08 September,
+  2023.
 name: MT Summit 2023
 id: mt-summit-2023
 description: Machine Translation Summit

--- a/events/mtm-2019.md
+++ b/events/mtm-2019.md
@@ -7,9 +7,9 @@ layout: event
 title: MTM 2019
 end_date: '2019-08-31'
 future_tense_opening_paragraph: The Machine Translation Marathon (<strong>MTM 2019</strong>)
-  will take place in  Edinburgh, Scotland from 26 to 31 August, 2019.
+  will take place in  Edinburgh, Scotland from 26 August to 31 August, 2019.
 past_tense_opening_paragraph: The Machine Translation Marathon (<strong>MTM 2019</strong>)
-  took place in  Edinburgh, Scotland from 26 to 31 August, 2019.
+  took place in  Edinburgh, Scotland from 26 August to 31 August, 2019.
 name: MTM 2019
 id: mtm-2019
 description: Machine Translation Marathon

--- a/events/mtm-2022.md
+++ b/events/mtm-2022.md
@@ -7,9 +7,9 @@ layout: event
 title: MTM 2022
 end_date: '2022-09-10'
 future_tense_opening_paragraph: The Machine Translation Marathon (<strong>MTM 2022</strong>)
-  will take place in Prague, Czech Republic from 05 to 10 September, 2022.
+  will take place in Prague, Czech Republic from 05 September to 10 September, 2022.
 past_tense_opening_paragraph: The Machine Translation Marathon (<strong>MTM 2022</strong>)
-  took place in Prague, Czech Republic from 05 to 10 September, 2022.
+  took place in Prague, Czech Republic from 05 September to 10 September, 2022.
 name: MTM 2022
 id: mtm-2022
 description: Machine Translation Marathon

--- a/events/mtm-2023.md
+++ b/events/mtm-2023.md
@@ -7,9 +7,9 @@ layout: event
 title: MTM 2023
 end_date: '2023-09-02'
 future_tense_opening_paragraph: The Machine Translation Marathon (<strong>MTM 2023</strong>)
-  will take place in Tartu, Estonia from 28 to 02 September, 2023.
+  will take place in Tartu, Estonia from 28 August to 02 September, 2023.
 past_tense_opening_paragraph: The Machine Translation Marathon (<strong>MTM 2023</strong>)
-  took place in Tartu, Estonia from 28 to 02 September, 2023.
+  took place in Tartu, Estonia from 28 August to 02 September, 2023.
 name: MTM 2023
 id: mtm-2023
 description: Machine Translation Marathon

--- a/events/mtma-2022.md
+++ b/events/mtma-2022.md
@@ -7,11 +7,11 @@ layout: event
 title: MTMA 2022
 end_date: '2022-07-22'
 future_tense_opening_paragraph: The Machine Translation Marathon in the Americas (<strong>MTMA
-  2022</strong>) will take place in Redmond, United States of America from 18 to 22
-  July, 2022.
+  2022</strong>) will take place in Redmond, United States of America from 18 July
+  to 22 July, 2022.
 past_tense_opening_paragraph: The Machine Translation Marathon in the Americas (<strong>MTMA
-  2022</strong>) took place in Redmond, United States of America from 18 to 22 July,
-  2022.
+  2022</strong>) took place in Redmond, United States of America from 18 July to 22
+  July, 2022.
 name: MTMA 2022
 id: mtma-2022
 description: Machine Translation Marathon in the Americas

--- a/events/mtma-2023.md
+++ b/events/mtma-2023.md
@@ -7,9 +7,10 @@ layout: event
 title: MTMA 2023
 end_date: '2023-06-09'
 future_tense_opening_paragraph: The Machine Translation Marathon in the Americas (<strong>MTMA
-  2023</strong>) will take place in Fairfax, United States from 05 to 09 June, 2023.
+  2023</strong>) will take place in Fairfax, United States from 05 June to 09 June,
+  2023.
 past_tense_opening_paragraph: The Machine Translation Marathon in the Americas (<strong>MTMA
-  2023</strong>) took place in Fairfax, United States from 05 to 09 June, 2023.
+  2023</strong>) took place in Fairfax, United States from 05 June to 09 June, 2023.
 name: MTMA 2023
 id: mtma-2023
 description: Machine Translation Marathon in the Americas

--- a/events/nettt-2022.md
+++ b/events/nettt-2022.md
@@ -7,9 +7,9 @@ layout: event
 title: NeTTT 2022
 end_date: '2022-07-06'
 future_tense_opening_paragraph: The New Trends in Translation and Technology (<strong>NeTTT
-  2022</strong>) will take place in Rhodes, Greece from 02 to 06 July, 2022.
+  2022</strong>) will take place in Rhodes, Greece from 02 July to 06 July, 2022.
 past_tense_opening_paragraph: The New Trends in Translation and Technology (<strong>NeTTT
-  2022</strong>) took place in Rhodes, Greece from 02 to 06 July, 2022.
+  2022</strong>) took place in Rhodes, Greece from 02 July to 06 July, 2022.
 name: NeTTT 2022
 id: nettt-2022
 description: New Trends in Translation and Technology

--- a/events/nettt-2024.md
+++ b/events/nettt-2024.md
@@ -7,9 +7,9 @@ layout: event
 title: NeTTT 2024
 end_date: '2024-07-06'
 future_tense_opening_paragraph: The New Trends in Translation and Technology (<strong>NeTTT
-  2024</strong>) will take place in Varna, Bulgaria from 03 to 06 July, 2024.
+  2024</strong>) will take place in Varna, Bulgaria from 03 July to 06 July, 2024.
 past_tense_opening_paragraph: The New Trends in Translation and Technology (<strong>NeTTT
-  2024</strong>) took place in Varna, Bulgaria from 03 to 06 July, 2024.
+  2024</strong>) took place in Varna, Bulgaria from 03 July to 06 July, 2024.
 name: NeTTT 2024
 id: nettt-2024
 description: New Trends in Translation and Technology

--- a/events/taus-2022.md
+++ b/events/taus-2022.md
@@ -7,9 +7,10 @@ layout: event
 title: TAUS 2022
 end_date: '2022-10-13'
 future_tense_opening_paragraph: The Massively Multilingual Conference & Expo (<strong>TAUS
-  2022</strong>) will take place in California, US from 11 to 13 October, 2022.
+  2022</strong>) will take place in California, US from 11 October to 13 October,
+  2022.
 past_tense_opening_paragraph: The Massively Multilingual Conference & Expo (<strong>TAUS
-  2022</strong>) took place in California, US from 11 to 13 October, 2022.
+  2022</strong>) took place in California, US from 11 October to 13 October, 2022.
 name: TAUS 2022
 id: taus-2022
 description: Massively Multilingual Conference & Expo

--- a/events/taus-2023.md
+++ b/events/taus-2023.md
@@ -7,9 +7,11 @@ layout: event
 title: TAUS 2023
 end_date: '2023-10-06'
 future_tense_opening_paragraph: The TAUS Annual Conference 2023 (<strong>TAUS 2023</strong>)
-  will take place in Salt Lake City, Utah, United States from 04 to 06 October, 2023.
+  will take place in Salt Lake City, Utah, United States from 04 October to 06 October,
+  2023.
 past_tense_opening_paragraph: The TAUS Annual Conference 2023 (<strong>TAUS 2023</strong>)
-  took place in Salt Lake City, Utah, United States from 04 to 06 October, 2023.
+  took place in Salt Lake City, Utah, United States from 04 October to 06 October,
+  2023.
 name: TAUS 2023
 id: taus-2023
 description: TAUS Annual Conference 2023

--- a/events/tcc44.md
+++ b/events/tcc44.md
@@ -7,9 +7,10 @@ layout: event
 title: TCC44
 end_date: '2022-11-25'
 future_tense_opening_paragraph: The Translating and the Computer conference (<strong>TCC44</strong>)
-  will take place in Luxembourg City, Luxembourg from 24 to 25 November, 2022.
+  will take place in Luxembourg City, Luxembourg from 24 November to 25 November,
+  2022.
 past_tense_opening_paragraph: The Translating and the Computer conference (<strong>TCC44</strong>)
-  took place in Luxembourg City, Luxembourg from 24 to 25 November, 2022.
+  took place in Luxembourg City, Luxembourg from 24 November to 25 November, 2022.
 name: TCC44
 id: tcc44
 description: Translating and the Computer conference

--- a/events/wat-2022.md
+++ b/events/wat-2022.md
@@ -7,9 +7,9 @@ layout: event
 title: WAT 2022
 end_date: '2022-10-17'
 future_tense_opening_paragraph: The Workshop on Asian Translation (<strong>WAT 2022</strong>)
-  will take place in Gyeongju, Republic of Korea from 12 to 17 October, 2022.
+  will take place in Gyeongju, Republic of Korea from 12 October to 17 October, 2022.
 past_tense_opening_paragraph: The Workshop on Asian Translation (<strong>WAT 2022</strong>)
-  took place in Gyeongju, Republic of Korea from 12 to 17 October, 2022.
+  took place in Gyeongju, Republic of Korea from 12 October to 17 October, 2022.
 name: WAT 2022
 id: wat-2022
 description: Workshop on Asian Translation

--- a/events/wmt06.md
+++ b/events/wmt06.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT06
 end_date: '2006-06-09'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT06</strong>)
-  will take place in New York, United States of America from 08 to 09 June, 2006.
+  will take place in New York, United States of America from 08 June to 09 June, 2006.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT06</strong>)
-  took place in New York, United States of America from 08 to 09 June, 2006.
+  took place in New York, United States of America from 08 June to 09 June, 2006.
 name: WMT06
 id: wmt06
 description: Workshop on Machine Translation

--- a/events/wmt07.md
+++ b/events/wmt07.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT07
 end_date: '2007-06-23'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT07</strong>)
-  will take place in Prague, Czech Republic from 23 to 23 June, 2007.
+  will take place in Prague, Czech Republic from 23 June to 23 June, 2007.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT07</strong>)
-  took place in Prague, Czech Republic from 23 to 23 June, 2007.
+  took place in Prague, Czech Republic from 23 June to 23 June, 2007.
 name: WMT07
 id: wmt07
 description: Workshop on Machine Translation

--- a/events/wmt08.md
+++ b/events/wmt08.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT08
 end_date: '2008-06-19'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT08</strong>)
-  will take place in Columbus, Unites States of America from 19 to 19 June, 2008.
+  will take place in Columbus, Unites States of America from 19 June to 19 June, 2008.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT08</strong>)
-  took place in Columbus, Unites States of America from 19 to 19 June, 2008.
+  took place in Columbus, Unites States of America from 19 June to 19 June, 2008.
 name: WMT08
 id: wmt08
 description: Workshop on Machine Translation

--- a/events/wmt09.md
+++ b/events/wmt09.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT09
 end_date: '2009-03-31'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT09</strong>)
-  will take place in Athens, Greece from 30 to 31 March, 2009.
+  will take place in Athens, Greece from 30 March to 31 March, 2009.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT09</strong>)
-  took place in Athens, Greece from 30 to 31 March, 2009.
+  took place in Athens, Greece from 30 March to 31 March, 2009.
 name: WMT09
 id: wmt09
 description: Workshop on Machine Translation

--- a/events/wmt10.md
+++ b/events/wmt10.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT10
 end_date: '2010-07-16'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT10</strong>)
-  will take place in Uppsala, Sweden from 15 to 16 July, 2010.
+  will take place in Uppsala, Sweden from 15 July to 16 July, 2010.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT10</strong>)
-  took place in Uppsala, Sweden from 15 to 16 July, 2010.
+  took place in Uppsala, Sweden from 15 July to 16 July, 2010.
 name: WMT10
 id: wmt10
 description: Workshop on Machine Translation

--- a/events/wmt11.md
+++ b/events/wmt11.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT11
 end_date: '2011-07-31'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT11</strong>)
-  will take place in Edinburgh, United Kingdom from 30 to 31 July, 2011.
+  will take place in Edinburgh, United Kingdom from 30 July to 31 July, 2011.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT11</strong>)
-  took place in Edinburgh, United Kingdom from 30 to 31 July, 2011.
+  took place in Edinburgh, United Kingdom from 30 July to 31 July, 2011.
 name: WMT11
 id: wmt11
 description: Workshop on Machine Translation

--- a/events/wmt12.md
+++ b/events/wmt12.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT12
 end_date: '2012-06-08'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT12</strong>)
-  will take place in Quebec, Canada from 07 to 08 June, 2012.
+  will take place in Quebec, Canada from 07 June to 08 June, 2012.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT12</strong>)
-  took place in Quebec, Canada from 07 to 08 June, 2012.
+  took place in Quebec, Canada from 07 June to 08 June, 2012.
 name: WMT12
 id: wmt12
 description: Workshop on Machine Translation

--- a/events/wmt13.md
+++ b/events/wmt13.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT13
 end_date: '2013-08-09'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT13</strong>)
-  will take place in Sofia, Bulgaria from 08 to 09 August, 2013.
+  will take place in Sofia, Bulgaria from 08 August to 09 August, 2013.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT13</strong>)
-  took place in Sofia, Bulgaria from 08 to 09 August, 2013.
+  took place in Sofia, Bulgaria from 08 August to 09 August, 2013.
 name: WMT13
 id: wmt13
 description: Workshop on Machine Translation

--- a/events/wmt14.md
+++ b/events/wmt14.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT14
 end_date: '2014-06-27'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT14</strong>)
-  will take place in Maryland, United States of America from 26 to 27 June, 2014.
+  will take place in Maryland, United States of America from 26 June to 27 June, 2014.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT14</strong>)
-  took place in Maryland, United States of America from 26 to 27 June, 2014.
+  took place in Maryland, United States of America from 26 June to 27 June, 2014.
 name: WMT14
 id: wmt14
 description: Workshop on Machine Translation

--- a/events/wmt15.md
+++ b/events/wmt15.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT15
 end_date: '2015-09-18'
 future_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT15</strong>)
-  will take place in Lisbon, Portugal from 17 to 18 September, 2015.
+  will take place in Lisbon, Portugal from 17 September to 18 September, 2015.
 past_tense_opening_paragraph: The Workshop on Machine Translation (<strong>WMT15</strong>)
-  took place in Lisbon, Portugal from 17 to 18 September, 2015.
+  took place in Lisbon, Portugal from 17 September to 18 September, 2015.
 name: WMT15
 id: wmt15
 description: Workshop on Machine Translation

--- a/events/wmt16.md
+++ b/events/wmt16.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT16
 end_date: '2016-08-12'
 future_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT16</strong>)
-  will take place in Berlin, Germany from 11 to 12 August, 2016.
+  will take place in Berlin, Germany from 11 August to 12 August, 2016.
 past_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT16</strong>)
-  took place in Berlin, Germany from 11 to 12 August, 2016.
+  took place in Berlin, Germany from 11 August to 12 August, 2016.
 name: WMT16
 id: wmt16
 description: Conference on Machine Translation

--- a/events/wmt17.md
+++ b/events/wmt17.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT17
 end_date: '2017-09-08'
 future_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT17</strong>)
-  will take place in Copenhagen, Denmark from 07 to 08 September, 2017.
+  will take place in Copenhagen, Denmark from 07 September to 08 September, 2017.
 past_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT17</strong>)
-  took place in Copenhagen, Denmark from 07 to 08 September, 2017.
+  took place in Copenhagen, Denmark from 07 September to 08 September, 2017.
 name: WMT17
 id: wmt17
 description: Conference on Machine Translation

--- a/events/wmt18.md
+++ b/events/wmt18.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT18
 end_date: '2018-11-01'
 future_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT18</strong>)
-  will take place in Brussels, Belgium from 31 to 01 November, 2018.
+  will take place in Brussels, Belgium from 31 October to 01 November, 2018.
 past_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT18</strong>)
-  took place in Brussels, Belgium from 31 to 01 November, 2018.
+  took place in Brussels, Belgium from 31 October to 01 November, 2018.
 name: WMT18
 id: wmt18
 description: Conference on Machine Translation

--- a/events/wmt19.md
+++ b/events/wmt19.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT19
 end_date: '2019-08-02'
 future_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT19</strong>)
-  will take place in Florence, Italy from 01 to 02 August, 2019.
+  will take place in Florence, Italy from 01 August to 02 August, 2019.
 past_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT19</strong>)
-  took place in Florence, Italy from 01 to 02 August, 2019.
+  took place in Florence, Italy from 01 August to 02 August, 2019.
 name: WMT19
 id: wmt19
 description: Conference on Machine Translation

--- a/events/wmt20.md
+++ b/events/wmt20.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT20
 end_date: '2020-11-11'
 future_tense_opening_paragraph: The None (<strong>WMT20</strong>) will take place
-  Online from 10 to 11 November, 2020.
+  Online from 10 November to 11 November, 2020.
 past_tense_opening_paragraph: The None (<strong>WMT20</strong>) took place Online
-  from 10 to 11 November, 2020.
+  from 10 November to 11 November, 2020.
 name: WMT20
 id: wmt20
 start_date: '2020-11-10'

--- a/events/wmt21.md
+++ b/events/wmt21.md
@@ -7,9 +7,11 @@ layout: wmt_event
 title: WMT21
 end_date: '2021-11-11'
 future_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT21</strong>)
-  will take place in LaAltagracia, Dominican Republic from 10 to 11 November, 2021.
+  will take place in LaAltagracia, Dominican Republic from 10 November to 11 November,
+  2021.
 past_tense_opening_paragraph: The Conference on Machine Translation (<strong>WMT21</strong>)
-  took place in LaAltagracia, Dominican Republic from 10 to 11 November, 2021.
+  took place in LaAltagracia, Dominican Republic from 10 November to 11 November,
+  2021.
 name: WMT21
 id: wmt21
 description: Conference on Machine Translation

--- a/events/wmt22.md
+++ b/events/wmt22.md
@@ -7,9 +7,10 @@ layout: wmt_event
 title: WMT22
 end_date: '2022-12-08'
 future_tense_opening_paragraph: The Seventh Conference on Machine Translation (<strong>WMT22</strong>)
-  will take place in Abu Dhabi, United Arab Emirates from 07 to 08 December, 2022.
+  will take place in Abu Dhabi, United Arab Emirates from 07 December to 08 December,
+  2022.
 past_tense_opening_paragraph: The Seventh Conference on Machine Translation (<strong>WMT22</strong>)
-  took place in Abu Dhabi, United Arab Emirates from 07 to 08 December, 2022.
+  took place in Abu Dhabi, United Arab Emirates from 07 December to 08 December, 2022.
 name: WMT22
 id: wmt22
 description: Seventh Conference on Machine Translation

--- a/events/wmt23.md
+++ b/events/wmt23.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT23
 end_date: '2023-12-07'
 future_tense_opening_paragraph: The Eighth Conference on Machine Translation (<strong>WMT23</strong>)
-  will take place in Singapore from 06 to 07 December, 2023.
+  will take place in Singapore from 06 December to 07 December, 2023.
 past_tense_opening_paragraph: The Eighth Conference on Machine Translation (<strong>WMT23</strong>)
-  took place in Singapore from 06 to 07 December, 2023.
+  took place in Singapore from 06 December to 07 December, 2023.
 name: WMT23
 id: wmt23
 description: Eighth Conference on Machine Translation

--- a/events/wmt24.md
+++ b/events/wmt24.md
@@ -7,9 +7,9 @@ layout: wmt_event
 title: WMT24
 end_date: '2024-11-13'
 future_tense_opening_paragraph: The Ninth Conference on Machine Translation (<strong>WMT24</strong>)
-  will take place in Miami, Florida from 12 to 13 November, 2024.
+  will take place in Miami, Florida from 12 November to 13 November, 2024.
 past_tense_opening_paragraph: The Ninth Conference on Machine Translation (<strong>WMT24</strong>)
-  took place in Miami, Florida from 12 to 13 November, 2024.
+  took place in Miami, Florida from 12 November to 13 November, 2024.
 name: WMT24
 id: wmt24
 description: Ninth Conference on Machine Translation

--- a/generate.py
+++ b/generate.py
@@ -787,7 +787,7 @@ for event in EVENTS:
     organizer_url = event['organizer'].get('url', None)
     organizer_type = event['organizer'].get('type', None)
 
-  date = f'from {datetime.strftime(start_date, '%d') } to {datetime.strftime(end_date, '%d %B, %Y')}' if start_date != end_date else f'on {datetime.strftime(start_date, '%d %B, %Y')}'
+  date = f'from {datetime.strftime(start_date, '%d %B') } to {datetime.strftime(end_date, '%d %B, %Y')}' if start_date != end_date else f'on {datetime.strftime(start_date, '%d %B, %Y')}'
   location = f'in {location_name}' if location_name.lower() != 'online' else location_name
   future_tense_opening_paragraph = f'The {description} (<strong>{name}</strong>) will take place {location} {date}.'
   past_tense_opening_paragraph = f'The {description} (<strong>{name}</strong>) took place {location} {date}.'
@@ -881,7 +881,7 @@ for event in WMT_EVENTS:
     organizer_type = event['organizer'].get('type', None)
 
   # Generate opening pagaraph in future/past tense
-  date = f'from {datetime.strftime(start_date, '%d') } to {datetime.strftime(end_date, '%d %B, %Y')}'
+  date = f'from {datetime.strftime(start_date, '%d %B') } to {datetime.strftime(end_date, '%d %B, %Y')}'
   location = f'in {location_name}' if location_name.lower() != 'online' else location_name
   future_tense_opening_paragraph = f'The {description} (<strong>{name}</strong>) will take place {location} {date}.'
   past_tense_opening_paragraph = f'The {description} (<strong>{name}</strong>) took place {location} {date}.'

--- a/integrations/memoq.md
+++ b/integrations/memoq.md
@@ -20,6 +20,7 @@ api_integrations:
 - slug: amazon
   custom: true
   glossary: true
+  formality: true
   urls:
   - https://docs.memoq.com/current/en/Places/amazon-mt-plugin-settings.html
   name: Amazon Translate


### PR DESCRIPTION
# Description

Improved the way the start and end dates were generated for events by including the month in the start date just like it is included in the end date in the opening sentence to avoid the below 👇 
![2024-05-14 20 19 46](https://github.com/machinetranslate/machinetranslate.org/assets/94985882/5fea943c-8e31-4f53-9b9c-5916220c3a1d)

### Checklist:

- [x] I have read the [contributing guidelines](/CONTRIBUTING).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
