### PR TITLE
Remove "Tonga", it's always called "Tongan"

### DIFF
--- a/_data/languages.json
+++ b/_data/languages.json
@@ -5916,7 +5916,6 @@
             "ton"
         ],
         "names": [
-            "Tonga",
             "Tongan"
         ],
         "family": [


### PR DESCRIPTION
# Description

Change the name of the article from "Tonga" to "Tongan", and remove "Tonga", which is the name of the island, not an adjective.

## Type of PR

- Edits *Tonga*

### Checklist:

- [x] I have read the [contributing guidelines](/CONTRIBUTING).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
