### PR TITLE
Add Gronings language (ISO 639-3: gos) to languages.json

### DIFF
--- a/_data/languages.json
+++ b/_data/languages.json
@@ -6918,6 +6918,45 @@
     {
         "codes": [
             "gos"
+        ],
+        "names": [
+            "Gronings",
+            "Grunnegs",
+            "Grönnegs",
+            "Grunnings",
+            "Gronings Low Saxon",
+            "Groningen Low Saxon"
+        ],
+        "variant_names": [
+        "Kollumerpompsters",
+        "Westerkwartiers",
+        "Stadjeders",
+        "Hogelandsters",
+        "Oldambtsters",
+        "Westerwolds",
+        "Veenkoloniaals",
+        "Noord-Drents"
+        ],
+        "family": [
+            "gem",
+            "ine"
+        ],
+        "scripts": [
+            "Latn"
+        ],
+        "typology": {
+            "word_order": [
+                "V2",
+                "SVO",
+                "SOV"
+            ],
+            "morphosyntax": [
+                "fusional",
+                "synthetic"
+            ]
+        },
+        "territories": [
+            "nl"
         ]
     },
     {


### PR DESCRIPTION
# Description

Adds Gronings (code: gos) to languages.json following the instructions at [https://machinetranslate.org/gos](https://machinetranslate.org/gos)

### Checklist:

- [X] I have read the [contributing guidelines](/CONTRIBUTING).
- [X] I have followed the [style guide](http://machinetranslate.org/style).
