### PR TITLE
Add prompt/prompting to customisation.md and create a separate prompting.md page

### DIFF
--- a/features/customisation/customisation.md
+++ b/features/customisation/customisation.md
@@ -15,7 +15,7 @@ The most common type of customisation is [fine-tuning](/fine-tuning) on [paralle
 {% assign customisable_apis = '' | split: ',' %}
 
 {% for api in site.data.apis %}
-  {% if api.custom_languages or api.glossary or api.formality or api.adaptive or api.fine-tuning %}
+  {% if api.custom_languages or api.glossary or api.formality or api.adaptive or api.fine-tuning or api.prompt_required %}
     {% unless customisable_apis contains api %}
       {% assign customisable_apis = customisable_apis | push: api %}
     {% endunless %}
@@ -40,11 +40,12 @@ The most common type of customisation is [fine-tuning](/fine-tuning) on [paralle
     <ul>
     {% for api in customisable_apis %}
       <li>
-          <a href="/{{ api.slug }}">{{ api.name }}</a> {% if api.plugin %}(plugin){% endif %}
+          <a href="/{{ api.id }}">{{ api.name }}</a> {% if api.plugin %}(plugin){% endif %}
             {% if api.custom_languages or api.fine-tuning %}| <strong>fine-tuning</strong> support{% endif %}
             {% if api.glossary %}| <strong>glossary</strong> support{% endif %}
             {% if api.formality %}| <strong>formality</strong> support{% endif %}
             {% if api.adaptive %}| <strong>adaptive</strong> support{% endif %}
+            {% if api.prompt_required %}| <strong>prompt</strong> support{% endif %}
       </li>
     {% endfor %}
     </ul>
@@ -62,7 +63,7 @@ The most common type of customisation is [fine-tuning](/fine-tuning) on [paralle
     <ul>
     {% for qe in customisable_qe_apis %}
       <li>
-        <a href="/{{ qe.slug }}">{{ qe.name }}</a> {% if qe.plugin %}(plugin){% endif %}
+        <a href="/{{ qe.id }}">{{ qe.name }}</a> {% if qe.plugin %}(plugin){% endif %}
             | <strong>fine-tuning</strong> support
       </li>
     {% endfor %}

--- a/features/customisation/prompting.md
+++ b/features/customisation/prompting.md
@@ -1,0 +1,19 @@
+---
+grand_parent: Features
+parent: Customisation
+layout: coming_soon
+title: Prompting
+description:
+---
+
+## API support
+{% assign prompt_apis = site.data.apis | where: "prompt_required", true %}
+<ul>
+  {% for api in prompt_apis %}
+    <li>
+    <a href="/{{ api.id }}">
+        {{ api.name }}
+    </a>
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
# Description
- Added prompting as a feature in `customisation.md`
- Created seprate `prompting.md` 
- Fixed how slugs were given for APIs in customisation.md

## Type of PR

- Creates the article _[prompting.md]_
- Edits _[customisation.md]_

### Checklist:

- [x] I have read the [contributing guidelines](/CONTRIBUTING).
- [x] I have followed the [style guide](http://machinetranslate.org/style).
