### PR TITLE
Update apis.json with SonikaAI SaaS service

### DIFF
--- a/_data/apis.json
+++ b/_data/apis.json
@@ -8793,6 +8793,34 @@
         ]
     },
     {
+      "name": "SonikaAI",
+      "id": "sonikaai",
+      "company": "sonikaai",
+      "urls": [
+        "https://sonikaai.com",
+        "https://sonikaai.com/openapi.yaml"
+      ],
+      "self-serve": false,
+      "inputs": [
+        "file"
+      ],
+      "languages": [
+        "en",
+        "uk",
+        "de",
+        "fr",
+        "es",
+        "it",
+        "pt",
+        "nl",
+        "pl",
+        "ru",
+        "ja",
+        "ko",
+        "zh"
+      ]
+    },
+    {
         "name": "Sunda Translator",
         "id": "sunda",
         "company": "sunda-systems",


### PR DESCRIPTION
Adds SonikaAI as a new translation API listing.

## Type of PR

- Creates the article SonikaAI
- Other: adds a new entry to `_data/apis.json` (not self-serve — access via contact + manual pilot onboarding)

### Checklist:

- [x] I have read the contributing guidelines.
- [x] I have followed the style guide.